### PR TITLE
Add API key validation to workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -19,6 +19,20 @@ jobs:
   code-review:
     runs-on: ubuntu-latest
     steps:
+      - name: Check API Key
+        run: |
+          if [ -z "${{ secrets.GEMINI_API_KEY }}" ]; then
+            echo "❌ Error: GEMINI_API_KEY is not set in repository secrets"
+            echo "📝 Please add GEMINI_API_KEY to your repository secrets:"
+            echo "   1. Go to Settings → Secrets and variables → Actions"
+            echo "   2. Click 'New repository secret'"
+            echo "   3. Name: GEMINI_API_KEY"
+            echo "   4. Value: Your Google AI Studio API key"
+            echo "🔗 Get your API key at: https://makersuite.google.com/app/apikey"
+            exit 1
+          fi
+          echo "✅ GEMINI_API_KEY is configured"
+      
       - name: Gemini Code Review Bot
         uses: Nasubikun/ai-reviewer@v1
         with:


### PR DESCRIPTION
## Summary
Add a pre-check step to validate GEMINI_API_KEY configuration before running the review bot.

## Problem
Without this check, users encounter confusing authentication errors when GEMINI_API_KEY is not configured in repository secrets.

## Solution
- ✅ Add validation step that checks if GEMINI_API_KEY is set
- ✅ Provide clear error message with step-by-step setup instructions
- ✅ Include direct link to Google AI Studio for API key generation
- ✅ Fail fast with helpful guidance

## Benefits
- 🚀 **Faster debugging**: Immediately identify missing API key
- 📝 **Clear instructions**: Users know exactly how to fix the issue
- ⏱️ **Time saving**: No need to dig through cryptic error logs
- 🎯 **Better UX**: Friendly error messages with actionable steps

## Example Output
When API key is missing:
```
❌ Error: GEMINI_API_KEY is not set in repository secrets
📝 Please add GEMINI_API_KEY to your repository secrets:
   1. Go to Settings → Secrets and variables → Actions
   2. Click 'New repository secret'
   3. Name: GEMINI_API_KEY
   4. Value: Your Google AI Studio API key
🔗 Get your API key at: https://makersuite.google.com/app/apikey
```

When API key is configured:
```
✅ GEMINI_API_KEY is configured
```

## Test Plan
- [x] Verify error message when GEMINI_API_KEY is not set
- [x] Verify success message when GEMINI_API_KEY is configured
- [x] Ensure workflow continues normally after validation

🤖 Generated with [Claude Code](https://claude.ai/code)