### PR TITLE
Add conditional novelty requirements for undergraduate thesis repositories

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9,7 +9,7 @@ const EXCLUDE_PATHS = ((_a = process.env.EXCLUDE_PATHS) === null || _a === void 
 const LANGUAGE = process.env.LANGUAGE || "English";
 const PR_NUMBER = Number(process.env.GITHUB_PR_NUMBER) || 1;
 const MODEL_CODE = process.env.MODEL_CODE || "models/gemini-2.0-flash-exp";
-const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW || false;
+const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW === 'true';
 if (!GITHUB_TOKEN) {
     throw new Error("GITHUB_TOKEN is missing");
 }

--- a/dist/utils/createAcademicPrompt.js
+++ b/dist/utils/createAcademicPrompt.js
@@ -2,9 +2,13 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createAcademicReviewPrompt = createAcademicReviewPrompt;
 /**
+ * 学部論文リポジトリのパターン
+ */
+const UNDERGRADUATE_THESIS_PATTERN = /^smkwlab\/.*-sotsuron$/;
+/**
  * 学術論文レビュー用のプロンプトを生成する
  */
-function createAcademicReviewPrompt({ prTitle, prBody, diffText, language, }) {
+function createAcademicReviewPrompt({ prTitle, prBody, diffText, language, repoName, }) {
     return `
 You are an experienced faculty member in the School of Science and Engineering.
 Please review the student's academic paper from an educational perspective and provide constructive feedback to improve the quality of the paper.
@@ -32,7 +36,8 @@ Review perspectives:
    
 4. Research novelty and contribution
    - Clear differentiation from existing research
-   - Explanation of research significance and contributions
+   - Explanation of research significance and contributions${(repoName === null || repoName === void 0 ? void 0 : repoName.match(UNDERGRADUATE_THESIS_PATTERN)) ? `
+   - Note: For undergraduate thesis work, moderate novelty expectations are appropriate` : ''}
    
 5. Formal requirements
    - Citation format consistency
@@ -48,7 +53,9 @@ Feedback priority levels:
 Important instructions:
 - Provide educational and constructive feedback
 - Offer specific improvement suggestions
-- Minimize mere grammar or notation corrections
+- Minimize mere grammar or notation corrections${(repoName === null || repoName === void 0 ? void 0 : repoName.match(UNDERGRADUATE_THESIS_PATTERN)) ? `
+- For undergraduate thesis: Focus on fundamental research skills rather than groundbreaking novelty
+- Emphasize learning outcomes and research process understanding` : ''}
 - Write feedback in ${language}
 
 Paper Title: ${prTitle}

--- a/dist/utils/generateAcademicReview.js
+++ b/dist/utils/generateAcademicReview.js
@@ -13,6 +13,7 @@ exports.generateAcademicReviewObject = exports.generateAcademicReviewText = void
 const ai_1 = require("ai");
 const google_1 = require("@ai-sdk/google");
 const zod_1 = require("zod");
+const index_1 = require("./index");
 /**
  * 学術論文レビュー用のスキーマとアイコンマップ
  */
@@ -72,35 +73,6 @@ const academicPriorityOrder = {
     "GOOD_POINT": 999
 };
 /**
- * Generic retry function with exponential backoff
- */
-function withRetry(operation, options) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const { maxAttempts, initialDelayMs, backoffFactor, retryableError, onRetry } = options;
-        let lastError;
-        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-            try {
-                return yield operation(attempt);
-            }
-            catch (error) {
-                lastError = error;
-                if (!retryableError(error)) {
-                    throw error;
-                }
-                if (attempt >= maxAttempts) {
-                    break;
-                }
-                const delayMs = initialDelayMs * Math.pow(backoffFactor, attempt - 1);
-                if (onRetry) {
-                    onRetry(attempt, error);
-                }
-                yield new Promise(resolve => setTimeout(resolve, delayMs));
-            }
-        }
-        throw lastError;
-    });
-}
-/**
  * 学術論文レビュー用のテキスト生成関数
  */
 const generateAcademicReviewText = (params) => __awaiter(void 0, void 0, void 0, function* () {
@@ -121,7 +93,7 @@ const generateAcademicReviewObject = (params) => __awaiter(void 0, void 0, void 
     const isJapanese = userPrompt.includes('Japanese');
     const categoryMap = isJapanese ? categoryMapJa : categoryMapEn;
     try {
-        const { object } = yield withRetry((...args_1) => __awaiter(void 0, [...args_1], void 0, function* (attempt = 1) {
+        const { object } = yield (0, index_1.withRetry)((...args_1) => __awaiter(void 0, [...args_1], void 0, function* (attempt = 1) {
             return yield (0, ai_1.generateObject)({
                 schema: academicReviewSchema,
                 model: (0, google_1.google)(modelCode),

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -24,6 +24,35 @@ const minimatch_1 = require("minimatch");
 const diff_1 = require("diff");
 const zod_1 = require("zod");
 /**
+ * Generic retry function with exponential backoff
+ */
+function withRetry(operation, options) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { maxAttempts, initialDelayMs, backoffFactor, retryableError, onRetry } = options;
+        let lastError;
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return yield operation(attempt);
+            }
+            catch (error) {
+                lastError = error;
+                if (!retryableError(error)) {
+                    throw error; // Not retryable, rethrow immediately
+                }
+                if (attempt >= maxAttempts) {
+                    break; // Will throw the last error after the loop
+                }
+                const delayMs = initialDelayMs * Math.pow(backoffFactor, attempt - 1);
+                if (onRetry) {
+                    onRetry(attempt, error);
+                }
+                yield new Promise(resolve => setTimeout(resolve, delayMs));
+            }
+        }
+        throw lastError;
+    });
+}
+/**
  * GitHub の PR 情報を取得
  */
 function fetchPullRequest(octokit, owner, repo, pullNumber) {
@@ -78,10 +107,10 @@ Important rules about the diff format:
 - Lines that begin with a space " " are context lines, which have not changed.
 
 Review guidelines:
-- Ignore changes that only involve whitespace, indentation, or formatting that do not affect the code’s behavior.
-- Do not add any review comments for trivial or non-impactful changes (e.g., variable name changes that do not affect logic).
-- For suggestions, assign a priority (e.g., PRIORITY:HIGH, PRIORITY:MEDIUM, PRIORITY:LOW).
-- Use type=POSITIVE only for changes that bring a clear, significant improvement to readability, performance, or maintainability. If a change is merely "not a problem," do not comment on it.
+- Ignore changes that only involve whitespace, indentation, or formatting that do not affect the code's behavior.
+- Do not add any review comments for trivial or non-impactful changes (e.g., variable-name changes that do not affect logic).
+- For suggestions, assign a priority. Only the following labels are allowed: HIGH, MEDIUM, LOW, or POSITIVE.
+- Use type=POSITIVE only for changes that bring a clear, significant improvement to readability, performance, or maintainability. If a change is merely “not a problem,” do not comment on it.
 - Your review must be written in ${language}.
 
 
@@ -191,6 +220,10 @@ const generateReviewCommentText = (params) => __awaiter(void 0, void 0, void 0, 
 exports.generateReviewCommentText = generateReviewCommentText;
 const generateReviewCommentObject = (params) => __awaiter(void 0, void 0, void 0, function* () {
     const { modelCode, userPrompt } = params;
+    // read testPrompt from a file named "testPrompt.txt` in the same directory
+    // this file is comes from: https://github.com/Nasubikun/ai-reviewer/issues/1
+    // const testPromptPath = path.join(process.cwd(), 'src', 'utils', 'testPrompt.txt');
+    // const testPromptText = await fs.readFile(testPromptPath, 'utf-8');
     const commentSchema = zod_1.z.object({
         path: zod_1.z
             .string()
@@ -205,9 +238,9 @@ const generateReviewCommentObject = (params) => __awaiter(void 0, void 0, void 0
             .positive()
             .describe("The 1-based line number where the comment is placed. " +
             "This corresponds to the modified (new) line in the diff or the final file."),
-        type: zod_1.z
-            .enum(["PRIORITY:HIGH", "PRIORITY:MEDIUM", "PRIORITY:LOW", "POSITIVE"])
-            .describe("The type of this comment. For suggestions, set its priority as like 'PRIORITY:HIGH', 'PRIORITY:MEDIUM', or 'PRIORITY:LOW'. For positive comments, it should be 'POSITIVE'."),
+        priority: zod_1.z
+            .enum(["HIGH", "MEDIUM", "LOW", "POSITIVE"])
+            .describe("The priority of this fix. For suggestions, set its priority as like 'HIGH', 'MEDIUM', or 'LOW'. For positive comments, it should be 'POSITIVE'."),
     });
     const reviewSchema = zod_1.z.object({
         body: zod_1.z
@@ -215,37 +248,53 @@ const generateReviewCommentObject = (params) => __awaiter(void 0, void 0, void 0
             .describe("Represents the overall body text of the review, providing a summary or context for the accompanying line-level comments."),
         comments: zod_1.z.array(commentSchema),
     });
-    const { object } = yield (0, ai_1.generateObject)({
-        schema: reviewSchema,
-        model: (0, google_1.google)(modelCode),
-        prompt: userPrompt,
-    });
-    const iconMap = {
-        "PRIORITY:HIGH": ":rotating_light:",
-        "PRIORITY:MEDIUM": ":warning:",
-        "PRIORITY:LOW": ":information_source:",
-        "POSITIVE": ":sparkles:"
-    };
-    const priorityOrder = {
-        "PRIORITY:HIGH": 0,
-        "PRIORITY:MEDIUM": 1,
-        "PRIORITY:LOW": 2,
-        "POSITIVE": 999
-    };
-    const parseCommentType = (type) => {
-        if (type.startsWith("PRIORITY:")) {
-            return type.replace("PRIORITY:", "");
-        }
-        return type;
-    };
-    return {
-        body: object.body,
-        comments: object.comments
-            .sort((a, b) => priorityOrder[a.type] - priorityOrder[b.type])
-            .map((comment) => {
-            return Object.assign(Object.assign({}, comment), { body: `${iconMap[comment.type]} [${parseCommentType(comment.type)}] ${comment.body}`, type: undefined });
-        }),
-    };
+    try {
+        // Use the retry mechanism for handling NoObjectGeneratedError
+        const { object } = yield withRetry((...args_1) => __awaiter(void 0, [...args_1], void 0, function* (attempt = 1) {
+            return yield (0, ai_1.generateObject)({
+                schema: reviewSchema,
+                model: (0, google_1.google)(modelCode),
+                prompt: userPrompt,
+                // Use temperature 0 for first attempt, 0.5 for retries
+                temperature: attempt === 1 ? 0 : 0.5
+            });
+        }), {
+            maxAttempts: 3,
+            initialDelayMs: 2000,
+            backoffFactor: 1.5,
+            retryableError: (error) => {
+                return error instanceof ai_1.NoObjectGeneratedError;
+            },
+            onRetry: (attempt, error) => {
+                console.log(`Retry attempt ${attempt} after error: ${error.message}`);
+            }
+        });
+        const iconMap = {
+            "HIGH": ":rotating_light:",
+            "MEDIUM": ":warning:",
+            "LOW": ":information_source:",
+            "POSITIVE": ":sparkles:"
+        };
+        const priorityOrder = {
+            "HIGH": 0,
+            "MEDIUM": 1,
+            "LOW": 2,
+            "POSITIVE": 999
+        };
+        return {
+            body: object.body,
+            comments: object.comments
+                .sort((a, b) => priorityOrder[a.priority] - priorityOrder[b.priority])
+                .map((comment) => {
+                return Object.assign(Object.assign({}, comment), { body: `${iconMap[comment.priority]} [${comment.priority}] ${comment.body}`, priority: undefined });
+            }),
+        };
+    }
+    catch (error) {
+        // If object generation fails after all retries, fall back to text generation
+        console.log("Failed to generate structured review after all retries. Falling back to text generation.");
+        return yield (0, exports.generateReviewCommentText)(params);
+    }
 });
 exports.generateReviewCommentObject = generateReviewCommentObject;
 function runReviewBotVercelAI(_a) {
@@ -271,8 +320,15 @@ function runReviewBotVercelAI(_a) {
             });
             console.log("--- Prompt ---");
             console.log(userPrompt);
-            // 7. AI にレビュー文を生成してもらう
-            const reviewCommentContent = yield generateReviewCommentFn({ modelCode, userPrompt });
+            // 7. AI にレビュー文を生成してもらう (with improved error handling)
+            let reviewCommentContent;
+            try {
+                reviewCommentContent = yield generateReviewCommentFn({ modelCode, userPrompt });
+            }
+            catch (error) {
+                console.error("Failed to generate review comment after retries:", error);
+                throw error; // Re-throw to be caught by the outer try-catch
+            }
             console.log("--- Review ---");
             console.log(reviewCommentContent);
             // 8. GitHub にレビュー文を投稿
@@ -286,6 +342,7 @@ function runReviewBotVercelAI(_a) {
         }
         catch (error) {
             console.error("Error in runReviewBotVercelAI:", error);
+            throw error;
         }
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const EXCLUDE_PATHS = process.env.EXCLUDE_PATHS?.split(',').map(p => p.trim()) |
 const LANGUAGE = process.env.LANGUAGE || "English"
 const PR_NUMBER = Number(process.env.GITHUB_PR_NUMBER) || 1;
 const MODEL_CODE = process.env.MODEL_CODE || "models/gemini-2.0-flash-exp"
-const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW || false
+const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW === 'true'
 
 if (!GITHUB_TOKEN) {
     throw new Error("GITHUB_TOKEN is missing");

--- a/src/utils/createAcademicPrompt.ts
+++ b/src/utils/createAcademicPrompt.ts
@@ -6,11 +6,13 @@ export function createAcademicReviewPrompt({
     prBody,
     diffText,
     language,
+    repoName,
 }: {
     prTitle: string;
     prBody: string | null;
     diffText: string;
     language: string;
+    repoName?: string;
 }): string {
     return `
 You are an experienced faculty member in the School of Science and Engineering.
@@ -39,7 +41,8 @@ Review perspectives:
    
 4. Research novelty and contribution
    - Clear differentiation from existing research
-   - Explanation of research significance and contributions
+   - Explanation of research significance and contributions${repoName?.match(/smkwlab\/.*-sotsuron$/) ? `
+   - Note: For undergraduate thesis work, moderate novelty expectations are appropriate` : ''}
    
 5. Formal requirements
    - Citation format consistency
@@ -55,7 +58,9 @@ Feedback priority levels:
 Important instructions:
 - Provide educational and constructive feedback
 - Offer specific improvement suggestions
-- Minimize mere grammar or notation corrections
+- Minimize mere grammar or notation corrections${repoName?.match(/smkwlab\/.*-sotsuron$/) ? `
+- For undergraduate thesis: Focus on fundamental research skills rather than groundbreaking novelty
+- Emphasize learning outcomes and research process understanding` : ''}
 - Write feedback in ${language}
 
 Paper Title: ${prTitle}

--- a/src/utils/createAcademicPrompt.ts
+++ b/src/utils/createAcademicPrompt.ts
@@ -1,4 +1,9 @@
 /**
+ * 学部論文リポジトリのパターン
+ */
+const UNDERGRADUATE_THESIS_PATTERN = /^smkwlab\/.*-sotsuron$/;
+
+/**
  * 学術論文レビュー用のプロンプトを生成する
  */
 export function createAcademicReviewPrompt({
@@ -41,7 +46,7 @@ Review perspectives:
    
 4. Research novelty and contribution
    - Clear differentiation from existing research
-   - Explanation of research significance and contributions${repoName?.match(/smkwlab\/.*-sotsuron$/) ? `
+   - Explanation of research significance and contributions${repoName?.match(UNDERGRADUATE_THESIS_PATTERN) ? `
    - Note: For undergraduate thesis work, moderate novelty expectations are appropriate` : ''}
    
 5. Formal requirements
@@ -58,7 +63,7 @@ Feedback priority levels:
 Important instructions:
 - Provide educational and constructive feedback
 - Offer specific improvement suggestions
-- Minimize mere grammar or notation corrections${repoName?.match(/smkwlab\/.*-sotsuron$/) ? `
+- Minimize mere grammar or notation corrections${repoName?.match(UNDERGRADUATE_THESIS_PATTERN) ? `
 - For undergraduate thesis: Focus on fundamental research skills rather than groundbreaking novelty
 - Emphasize learning outcomes and research process understanding` : ''}
 - Write feedback in ${language}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -176,7 +176,7 @@ Important rules about the diff format:
 Review guidelines:
 - Ignore changes that only involve whitespace, indentation, or formatting that do not affect the code's behavior.
 - Do not add any review comments for trivial or non-impactful changes (e.g., variable-name changes that do not affect logic).
-- For suggestions, assign a priority. Only the following labels are allowed: PRIORITY:HIGH, PRIORITY:MEDIUM, PRIORITY:LOW, or POSITIVE.
+- For suggestions, assign a priority. Only the following labels are allowed: HIGH, MEDIUM, LOW, or POSITIVE.
 - Use type=POSITIVE only for changes that bring a clear, significant improvement to readability, performance, or maintainability. If a change is merely “not a problem,” do not comment on it.
 - Your review must be written in ${language}.
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -90,7 +90,13 @@ interface ReviewBotOptions {
     modelCode: string;
     generateReviewCommentFn: GenerateReviewCommentFn
     postReviewCommentFn: PostReviewCommentFn;
-    createPromptFn?: typeof createReviewPrompt;
+    createPromptFn?: (params: {
+        prTitle: string;
+        prBody: string | null;
+        diffText: string;
+        language: string;
+        repoName?: string;
+    }) => string;
 }
 
 export type GenerateReviewCommentFn = (params: GenerateReviewCommentFnParams) => Promise<ReviewCommentContent>
@@ -164,11 +170,13 @@ export function createReviewPrompt({
     prBody,
     diffText,
     language,
+    repoName,
 }: {
     prTitle: string;
     prBody: string | null;
     diffText: string;
     language: string;
+    repoName?: string;
 }): string {
     return `
 You are an experienced professor in the School of Science and Engineering.
@@ -449,6 +457,7 @@ export async function runReviewBotVercelAI({
             prBody: prData.body,
             diffText,
             language,
+            repoName: `${owner}/${repo}`,
         });
 
         console.log("--- Prompt ---");

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,7 +15,7 @@ export { generateAcademicReviewObject, generateAcademicReviewText } from './gene
 /**
  * Generic retry function with exponential backoff
  */
-async function withRetry<T>(
+export async function withRetry<T>(
     operation: (attempt?: number) => Promise<T>,
     options: {
         maxAttempts: number;


### PR DESCRIPTION
## Summary

- リポジトリ名が `smkwlab/*-sotsuron` にマッチする場合、論文の新規性要求を緩和
- 学部論文に適した教育的ガイダンスを追加
- レビュープロンプトにリポジトリ名パラメータを追加

## Changes

- `createAcademicReviewPrompt` 関数に `repoName` パラメータを追加
- 学部論文リポジトリの場合、適度な新規性期待値を設定
- 基礎的研究スキルと学習プロセス理解に重点を置く指導を追加
- 関数シグネチャを更新してリポジトリ固有のレビュー基準をサポート

## Test plan

- [ ] `smkwlab/*-sotsuron` パターンのリポジトリで新規性要求が緩和されることを確認
- [ ] 他のリポジトリでは従来通りの新規性要求が適用されることを確認
- [ ] 学部論文用の追加ガイダンスが適切に表示されることを確認