### PR TITLE
Fix code-review workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -22,23 +22,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check API Key
+        id: check-key
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
-          if [ -z "${{ secrets.GEMINI_API_KEY }}" ]; then
-            echo "❌ Error: GEMINI_API_KEY is not set in repository secrets"
-            echo "📝 Please add GEMINI_API_KEY to your repository secrets:"
-            echo "   1. Go to Settings → Secrets and variables → Actions"
-            echo "   2. Click 'New repository secret'"
-            echo "   3. Name: GEMINI_API_KEY"
-            echo "   4. Value: Your Google AI Studio API key"
-            echo "🔗 Get your API key at: https://makersuite.google.com/app/apikey"
-            exit 1
+          if [ -z "$GEMINI_API_KEY" ]; then
+            echo "::notice::GEMINI_API_KEY is not configured. Skipping code review."
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
           fi
-          echo "✅ GEMINI_API_KEY is configured"
       - name: Gemini Code Review Bot
-        uses: Nasubikun/ai-reviewer@v1
+        if: steps.check-key.outputs.skip != 'true'
+        uses: toshi0806/ai-reviewer@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           LANGUAGE: "English"
           EXCLUDE_PATHS: "node_modules/**,dist/**,*.lock,*.log"
-          MODEL_CODE: "models/gemini-2.0-flash"


### PR DESCRIPTION
## Summary
- Switch action from `Nasubikun/ai-reviewer@v1` to `toshi0806/ai-reviewer@v1` (maintained fork)
- Remove explicit `MODEL_CODE` specification to use default (`gemini-2.5-flash`)
- Fix API key check to use environment variable for security
- Add graceful skip when `GEMINI_API_KEY` is not configured

## Changes
1. **Action reference**: Updated to maintained fork with latest Gemini model defaults
2. **Model selection**: Removed hardcoded `gemini-2.0-flash` to inherit default `gemini-2.5-flash`
3. **Security fix**: API key check now uses environment variable instead of direct interpolation
4. **Graceful handling**: Workflow now skips with notice instead of failing when API key is missing