### PR TITLE
Enable Renovate processing on fork repository

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   "timezone": "Asia/Tokyo",
   "schedule": ["after 9pm on sunday"],
   "semanticCommits": "enabled",
+  "forkProcessing": "enabled",
   "packageRules": [
     {
       "description": "GitHub Actions version updates",


### PR DESCRIPTION
## Summary
Renovate はデフォルトで fork リポジトリを処理対象外とするため、Mend ダッシュボード上で本リポジトリが `disabled` 状態になっていました。`forkProcessing: "enabled"` を追加して明示的に有効化します。

## Background
- Mend ダッシュボードで確認したところ、他の4リポジトリは onboarding/onboarded となっていたが、本リポジトリのみ `disabled` 状態だった
- 原因: 本リポジトリは upstream からの fork であり、Renovate のデフォルト挙動で fork はスキップされる

## Change
```diff
+ "forkProcessing": "enabled",
```

## Reference
- [Renovate docs: forkProcessing](https://docs.renovatebot.com/configuration-options/#forkprocessing)