### PR TITLE
Pass GOOGLE_GENERATIVE_AI_API_KEY to fix AI review authentication

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,7 @@ runs:
       shell: bash
       env:
         GEMINI_API_KEY: ${{ inputs.GEMINI_API_KEY }}
+        GOOGLE_GENERATIVE_AI_API_KEY: ${{ inputs.GEMINI_API_KEY }}
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         GITHUB_OWNER: ${{ github.repository_owner }}
         GITHUB_REPO: ${{ github.event.pull_request.head.repo.name }}


### PR DESCRIPTION
## 概要

`action.yml` の env に `GOOGLE_GENERATIVE_AI_API_KEY: ${{ inputs.GEMINI_API_KEY }}` を追加し、AI レビューの認証失敗を修正する。

resolve #21

## 背景・根本原因

- `src/index.ts` は `process.env.GEMINI_API_KEY` を読むが、これは「未設定ならスキップ」する存在チェックにのみ使われている。
- 実際のモデル呼び出しは `google(modelCode)`（`@ai-sdk/google` v1.0.12 のデフォルトインスタンス）で行われ、`apiKey` を明示指定していない。
- そのため SDK は標準の環境変数 **`GOOGLE_GENERATIVE_AI_API_KEY`** からキーを読もうとするが、`action.yml` はこれを env に渡していなかった。
- 結果、`GEMINI_API_KEY` を設定してもスキップ判定は通過するが、実際の生成時に認証キーが見つからず失敗していた。

※ 同系統の `ai-reviewer` では `action.yml` でこの橋渡しを行っているため正常動作している。本リポジトリにはこの橋渡しが欠けていた。

## 変更内容

```diff
       env:
         GEMINI_API_KEY: ${{ inputs.GEMINI_API_KEY }}
+        GOOGLE_GENERATIVE_AI_API_KEY: ${{ inputs.GEMINI_API_KEY }}
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
```

- `GEMINI_API_KEY` は `index.ts` のスキップ判定で使われているため**維持**。
- SDK 認証用に `GOOGLE_GENERATIVE_AI_API_KEY` を**追加**。

## 影響範囲

- `action.yml` への1行追加のみ。**非破壊的変更**（既存の input 名 `GEMINI_API_KEY` は不変）。
- 利用側ワークフロー（`@v1` 参照）の変更は不要。
- ソース変更がないため `dist/` の再ビルドは不要。

## 確認方法

`GEMINI_API_KEY` を設定したリポジトリで PR を作成し、AI レビューが認証エラーなく実行されることを確認する。