### PR TITLE
Use shared Renovate preset from smkwlab/.github

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,33 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "dependencyDashboardLabels": ["dependencies"],
-  "extends": ["config:recommended", "workarounds:all"],
-  "timezone": "Asia/Tokyo",
-  "schedule": ["after 9pm on sunday"],
-  "semanticCommits": "enabled",
-  "forkProcessing": "enabled",
-  "packageRules": [
-    {
-      "description": "GitHub Actions version updates",
-      "matchManagers": ["github-actions"],
-      "pinDigests": true,
-      "labels": ["dependencies", "github-actions"],
-      "semanticCommitType": "ci"
-    },
-    {
-      "description": "Docker base image updates",
-      "matchManagers": ["dockerfile"],
-      "pinDigests": true,
-      "labels": ["dependencies", "docker"],
-      "semanticCommitType": "build"
-    },
-    {
-      "description": "npm dependency updates",
-      "matchManagers": ["npm"],
-      "labels": ["dependencies", "npm"],
-      "rangeStrategy": "bump",
-      "semanticCommitType": "chore"
-    }
-  ]
+  "extends": ["github>smkwlab/.github:latex#v1"],
+  "forkProcessing": "enabled"
 }


### PR DESCRIPTION
## Summary

Replace the duplicated Renovate configuration with a one-line `extends` of the org-wide shared preset, pinned to the `v1` tag — while **preserving the repo-specific `forkProcessing` setting** required for reviewing fork PRs.

```jsonc
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>smkwlab/.github:latex#v1"],
  "forkProcessing": "enabled"
}
```

The shared manager rules (github-actions/docker `pinDigests`, npm `bump`, weekly Sunday schedule, `workarounds:all`) now come from `smkwlab/.github` (`default.json` + `latex.json` @ `v1`), so behavior is preserved. Patch/digest auto-merge is added per the shared org policy. `forkProcessing: enabled` is kept locally because it is specific to this repository.

## Context

Part of the ecosystem-wide Renovate consolidation. Shared presets added/pinned in smkwlab/.github#28 and #29 (both merged, released as `v1.6.0`).
