### PR TITLE
ci: run unit tests, build, and dist freshness check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      # This action runs the committed dist/ at runtime, so it must match the
+      # source build. Fail if a source change wasn't rebuilt into dist/.
+      - name: Verify dist is up to date
+        run: |
+          if ! git diff --quiet -- dist; then
+            echo "::error::dist/ is out of date — run 'npm run build' and commit dist/."
+            git diff --stat -- dist
+            exit 1
+          fi


### PR DESCRIPTION
## 概要

PR #24 で vitest テストと tsc ビルドを導入したが、これらを回す CI が無かった。本 PR で CI ワークフローを追加する。

## 変更内容

`.github/workflows/ci.yml`（`pull_request` / `push: main`）:

1. `npm ci`
2. `npm test`（vitest）
3. `npm run build`（tsc）
4. **`dist` 鮮度チェック**: ビルド後に `git diff --quiet -- dist` が差分を検出したら fail

## なぜ dist チェックか

このアクションは**コミット済みの `dist/` を runtime で実行**する composite action。src を変えて `dist` をリビルドし忘れると、古い `dist` が動いてしまう。CI で「src の変更が `dist` に反映されているか」を強制する。

## 検証

- `actionlint`: クリーン
- ローカルで CI 手順を再現: `npm ci` → `npm test` **4/4 pass** → `npm run build` → **dist 差分なし**

これで今後、provider 追加のような変更でもテスト退行・dist 取り違えを CI で防げます。
