### PR TITLE
Harden inline review posting against out-of-diff lines

### DIFF
--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -17,6 +17,9 @@ exports.filterFiles = filterFiles;
 exports.parseFiles = parseFiles;
 exports.createReviewPrompt = createReviewPrompt;
 exports.createParsedDiffText = createParsedDiffText;
+exports.collectValidCommentLines = collectValidCommentLines;
+exports.partitionCommentsByValidLines = partitionCommentsByValidLines;
+exports.renderCommentsAsBodySection = renderCommentsAsBodySection;
 exports.runReviewBotVercelAI = runReviewBotVercelAI;
 const ai_1 = require("ai");
 const provider_1 = require("./provider");
@@ -216,6 +219,90 @@ function createParsedDiffText(parsedFiles) {
     })
         .join("\n");
 }
+/**
+ * Build, per file path, the set of new-file line numbers that can anchor an
+ * inline review comment — i.e. the lines present in the diff on the RIGHT side:
+ * added ("+") and context (" ") lines. Removed ("-") lines exist only on the
+ * old side and cannot anchor a RIGHT-side comment, and the "\ No newline at end
+ * of file" marker is not a real line.
+ *
+ * GitHub's review API rejects the WHOLE review (422 "line ... could not be
+ * resolved") if any single comment targets a line outside these, so callers use
+ * this to drop out-of-diff comments before posting.
+ */
+function collectValidCommentLines(parsedFiles) {
+    const map = new Map();
+    for (const file of parsedFiles) {
+        const lines = new Set();
+        for (const diff of file.patch) {
+            for (const hunk of diff.hunks) {
+                let newLine = hunk.newStart;
+                for (const line of hunk.lines) {
+                    switch (line[0]) {
+                        case "-":
+                            // old side only; does not advance the new-file line
+                            break;
+                        case "\\":
+                            // "\ No newline at end of file" — not a real line
+                            break;
+                        case "+":
+                            lines.add(newLine);
+                            newLine++;
+                            break;
+                        default:
+                            // context line: commentable and advances new-file line
+                            lines.add(newLine);
+                            newLine++;
+                            break;
+                    }
+                }
+            }
+        }
+        map.set(file.filename, lines);
+    }
+    return map;
+}
+/**
+ * Partition inline comments into those that target a line within the diff
+ * (`valid`) and those that do not (`invalid`), using the set built by
+ * {@link collectValidCommentLines}. A comment whose file is absent from the map,
+ * or whose line is undefined, is treated as invalid.
+ */
+function partitionCommentsByValidLines(comments, validLines) {
+    const valid = [];
+    const invalid = [];
+    for (const comment of comments) {
+        const set = validLines.get(comment.path);
+        if (comment.line != null && (set === null || set === void 0 ? void 0 : set.has(comment.line))) {
+            valid.push(comment);
+        }
+        else {
+            invalid.push(comment);
+        }
+    }
+    return { valid, invalid };
+}
+/** Heading for the folded-comments section, localized to the review language. */
+function foldedCommentsHeading(language) {
+    if (/japanese|日本語/i.test(language)) {
+        return "diff 範囲外のため inline で投稿できなかったコメント:";
+    }
+    return "Comments outside the diff (could not be posted inline):";
+}
+/**
+ * Render inline comments as a Markdown list so they can be folded into the
+ * review body when they cannot be posted inline (out-of-diff, or a failed
+ * inline post). Keeps the feedback visible instead of silently dropping it.
+ * The heading follows the review `language` (Japanese or English fallback).
+ */
+function renderCommentsAsBodySection(comments, language = "English") {
+    if (!comments.length)
+        return "";
+    const items = comments
+        .map((c) => { var _a; return `- \`${c.path}:${(_a = c.line) !== null && _a !== void 0 ? _a : "?"}\` — ${c.body}`; })
+        .join("\n");
+    return `\n\n---\n\n**${foldedCommentsHeading(language)}**\n${items}`;
+}
 const generateReviewCommentText = (params) => __awaiter(void 0, void 0, void 0, function* () {
     const { modelCode, userPrompt } = params;
     const { text } = yield (0, ai_1.generateText)({
@@ -306,6 +393,7 @@ const generateReviewCommentObject = (params) => __awaiter(void 0, void 0, void 0
 exports.generateReviewCommentObject = generateReviewCommentObject;
 function runReviewBotVercelAI(_a) {
     return __awaiter(this, arguments, void 0, function* ({ githubToken, owner, repo, pullNumber, excludePaths, language, modelCode, generateReviewCommentFn, postReviewCommentFn, createPromptFn = createReviewPrompt, }) {
+        var _b, _c, _d, _e;
         try {
             const octokit = new rest_1.Octokit({ auth: githubToken });
             // 1. PRデータの取得
@@ -339,14 +427,45 @@ function runReviewBotVercelAI(_a) {
             }
             console.log("--- Review ---");
             console.log(reviewCommentContent);
-            // 8. GitHub にレビュー文を投稿
-            yield postReviewCommentFn({
-                octokit,
-                owner,
-                repo,
-                pullNumber,
-                reviewCommentContent,
-            });
+            // 7.5 Filter inline comments to lines that are within the diff. GitHub's
+            // review API rejects the WHOLE review (422) if any comment targets a line
+            // outside the diff hunks, so drop those and fold them into the body so the
+            // feedback is preserved instead of silently lost.
+            if ((_b = reviewCommentContent.comments) === null || _b === void 0 ? void 0 : _b.length) {
+                const validLines = collectValidCommentLines(parsedFilesData);
+                const { valid, invalid } = partitionCommentsByValidLines(reviewCommentContent.comments, validLines);
+                if (invalid.length) {
+                    console.log(`Dropping ${invalid.length} inline comment(s) outside the diff; folding into the review body.`);
+                    reviewCommentContent = {
+                        body: ((_c = reviewCommentContent.body) !== null && _c !== void 0 ? _c : "") + renderCommentsAsBodySection(invalid, language),
+                        comments: valid,
+                    };
+                }
+            }
+            // 8. GitHub にレビュー文を投稿。万一インライン投稿が拒否されても（フィルタ
+            // が取りこぼした端ケース等）、コメントを body に畳んで要約のみで再投稿し、
+            // 「レビューは走ったが投稿ゼロ」の無言失敗を避ける。
+            try {
+                yield postReviewCommentFn({
+                    octokit,
+                    owner,
+                    repo,
+                    pullNumber,
+                    reviewCommentContent,
+                });
+            }
+            catch (postError) {
+                console.error("Inline review post failed; retrying as a body-only summary comment.", postError);
+                const foldedBody = ((_d = reviewCommentContent.body) !== null && _d !== void 0 ? _d : "") +
+                    renderCommentsAsBodySection((_e = reviewCommentContent.comments) !== null && _e !== void 0 ? _e : [], language);
+                yield postReviewCommentFn({
+                    octokit,
+                    owner,
+                    repo,
+                    pullNumber,
+                    reviewCommentContent: { body: foldedBody, comments: [] },
+                });
+            }
         }
         catch (error) {
             console.error("Error in runReviewBotVercelAI:", error);

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { parsePatch } from "diff";
+import {
+    collectValidCommentLines,
+    partitionCommentsByValidLines,
+    renderCommentsAsBodySection,
+} from "./index";
+
+// A GitHub `listFiles` patch is headerless and starts at the first @@ hunk.
+// Two hunks here exercise per-hunk newStart tracking and the +/-/context cases.
+const PATCH = [
+    "@@ -1,3 +1,4 @@",
+    " context1",
+    "-removed1",
+    "+added1",
+    "+added2",
+    " context2",
+    "@@ -10,2 +11,3 @@",
+    " context10",
+    "+added11",
+    " context11",
+].join("\n");
+
+const parsedFile = (filename: string, patch: string) => ({
+    filename,
+    patch: parsePatch(patch),
+});
+
+describe("collectValidCommentLines", () => {
+    it("includes added and context lines (new-file numbers), excludes removed lines", () => {
+        const map = collectValidCommentLines([parsedFile("a.ts", PATCH)]);
+        const lines = map.get("a.ts")!;
+        // hunk1: context1=1, added1=2, added2=3, context2=4 ; removed1 has no new line
+        // hunk2: context10=11, added11=12, context11=13
+        expect([...lines].sort((x, y) => x - y)).toEqual([1, 2, 3, 4, 11, 12, 13]);
+        // the removed-line's old number (2) must NOT be a valid new-side line here
+        expect(lines.has(5)).toBe(false);
+    });
+
+    it("handles files with no patch as an empty set", () => {
+        const map = collectValidCommentLines([{ filename: "empty.ts", patch: [] }]);
+        expect(map.get("empty.ts")!.size).toBe(0);
+    });
+
+    it("ignores the 'No newline at end of file' marker", () => {
+        const patch = ["@@ -1 +1 @@", "-old", "+new", "\\ No newline at end of file"].join("\n");
+        const map = collectValidCommentLines([parsedFile("n.ts", patch)]);
+        expect([...map.get("n.ts")!]).toEqual([1]); // only the added "new" line
+    });
+});
+
+describe("partitionCommentsByValidLines", () => {
+    const validLines = collectValidCommentLines([parsedFile("a.ts", PATCH)]);
+
+    it("keeps in-diff comments and rejects the rest", () => {
+        const comments = [
+            { path: "a.ts", line: 2, body: "in diff" },
+            { path: "a.ts", line: 5, body: "outside hunk" },
+            { path: "b.ts", line: 1, body: "unknown file" },
+            { path: "a.ts", body: "no line" },
+        ];
+        const { valid, invalid } = partitionCommentsByValidLines(comments, validLines);
+        expect(valid.map((c) => c.body)).toEqual(["in diff"]);
+        expect(invalid.map((c) => c.body).sort()).toEqual(
+            ["no line", "outside hunk", "unknown file"]
+        );
+    });
+
+    it("returns all-valid when every comment is in the diff", () => {
+        const comments = [
+            { path: "a.ts", line: 1, body: "ctx" },
+            { path: "a.ts", line: 12, body: "added in hunk2" },
+        ];
+        const { valid, invalid } = partitionCommentsByValidLines(comments, validLines);
+        expect(valid).toHaveLength(2);
+        expect(invalid).toHaveLength(0);
+    });
+});
+
+describe("renderCommentsAsBodySection", () => {
+    it("returns an empty string for no comments", () => {
+        expect(renderCommentsAsBodySection([])).toBe("");
+        expect(renderCommentsAsBodySection([], "Japanese")).toBe("");
+    });
+
+    it("renders a markdown list with path:line and body", () => {
+        const out = renderCommentsAsBodySection([
+            { path: "a.ts", line: 5, body: "msg" },
+            { path: "a.ts", body: "no line" },
+        ]);
+        expect(out).toContain("could not be posted inline");
+        expect(out).toContain("`a.ts:5` — msg");
+        expect(out).toContain("`a.ts:?` — no line");
+    });
+
+    it("uses an English heading by default and for non-Japanese languages", () => {
+        expect(renderCommentsAsBodySection([{ path: "a.ts", line: 5, body: "m" }])).toContain(
+            "Comments outside the diff"
+        );
+        expect(
+            renderCommentsAsBodySection([{ path: "a.ts", line: 5, body: "m" }], "English")
+        ).toContain("Comments outside the diff");
+    });
+
+    it("uses a Japanese heading when the language is Japanese", () => {
+        for (const lang of ["Japanese", "日本語"]) {
+            const out = renderCommentsAsBodySection([{ path: "a.ts", line: 5, body: "m" }], lang);
+            expect(out).toContain("diff 範囲外のため inline で投稿できなかったコメント");
+            expect(out).not.toContain("Comments outside the diff");
+        }
+    });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -309,6 +309,102 @@ export function createParsedDiffText(parsedFiles: ParsedPullRequestFile[]): stri
         .join("\n");
 }
 
+type InlineComment = NonNullable<ReviewCommentContent["comments"]>[number];
+
+/**
+ * Build, per file path, the set of new-file line numbers that can anchor an
+ * inline review comment — i.e. the lines present in the diff on the RIGHT side:
+ * added ("+") and context (" ") lines. Removed ("-") lines exist only on the
+ * old side and cannot anchor a RIGHT-side comment, and the "\ No newline at end
+ * of file" marker is not a real line.
+ *
+ * GitHub's review API rejects the WHOLE review (422 "line ... could not be
+ * resolved") if any single comment targets a line outside these, so callers use
+ * this to drop out-of-diff comments before posting.
+ */
+export function collectValidCommentLines(
+    parsedFiles: { filename: string; patch: ParsedDiff[] }[]
+): Map<string, Set<number>> {
+    const map = new Map<string, Set<number>>();
+    for (const file of parsedFiles) {
+        const lines = new Set<number>();
+        for (const diff of file.patch) {
+            for (const hunk of diff.hunks) {
+                let newLine = hunk.newStart;
+                for (const line of hunk.lines) {
+                    switch (line[0]) {
+                        case "-":
+                            // old side only; does not advance the new-file line
+                            break;
+                        case "\\":
+                            // "\ No newline at end of file" — not a real line
+                            break;
+                        case "+":
+                            lines.add(newLine);
+                            newLine++;
+                            break;
+                        default:
+                            // context line: commentable and advances new-file line
+                            lines.add(newLine);
+                            newLine++;
+                            break;
+                    }
+                }
+            }
+        }
+        map.set(file.filename, lines);
+    }
+    return map;
+}
+
+/**
+ * Partition inline comments into those that target a line within the diff
+ * (`valid`) and those that do not (`invalid`), using the set built by
+ * {@link collectValidCommentLines}. A comment whose file is absent from the map,
+ * or whose line is undefined, is treated as invalid.
+ */
+export function partitionCommentsByValidLines(
+    comments: InlineComment[],
+    validLines: Map<string, Set<number>>
+): { valid: InlineComment[]; invalid: InlineComment[] } {
+    const valid: InlineComment[] = [];
+    const invalid: InlineComment[] = [];
+    for (const comment of comments) {
+        const set = validLines.get(comment.path);
+        if (comment.line != null && set?.has(comment.line)) {
+            valid.push(comment);
+        } else {
+            invalid.push(comment);
+        }
+    }
+    return { valid, invalid };
+}
+
+/** Heading for the folded-comments section, localized to the review language. */
+function foldedCommentsHeading(language: string): string {
+    if (/japanese|日本語/i.test(language)) {
+        return "diff 範囲外のため inline で投稿できなかったコメント:";
+    }
+    return "Comments outside the diff (could not be posted inline):";
+}
+
+/**
+ * Render inline comments as a Markdown list so they can be folded into the
+ * review body when they cannot be posted inline (out-of-diff, or a failed
+ * inline post). Keeps the feedback visible instead of silently dropping it.
+ * The heading follows the review `language` (Japanese or English fallback).
+ */
+export function renderCommentsAsBodySection(
+    comments: InlineComment[],
+    language: string = "English"
+): string {
+    if (!comments.length) return "";
+    const items = comments
+        .map((c) => `- \`${c.path}:${c.line ?? "?"}\` — ${c.body}`)
+        .join("\n");
+    return `\n\n---\n\n**${foldedCommentsHeading(language)}**\n${items}`;
+}
+
 export const generateReviewCommentText: GenerateReviewCommentFn = async (params) => {
     const { modelCode, userPrompt } = params
     const { text } = await generateText({
@@ -475,14 +571,54 @@ export async function runReviewBotVercelAI({
         console.log("--- Review ---");
         console.log(reviewCommentContent);
 
-        // 8. GitHub にレビュー文を投稿
-        await postReviewCommentFn({
-            octokit,
-            owner,
-            repo,
-            pullNumber,
-            reviewCommentContent,
-        });
+        // 7.5 Filter inline comments to lines that are within the diff. GitHub's
+        // review API rejects the WHOLE review (422) if any comment targets a line
+        // outside the diff hunks, so drop those and fold them into the body so the
+        // feedback is preserved instead of silently lost.
+        if (reviewCommentContent.comments?.length) {
+            const validLines = collectValidCommentLines(parsedFilesData);
+            const { valid, invalid } = partitionCommentsByValidLines(
+                reviewCommentContent.comments,
+                validLines
+            );
+            if (invalid.length) {
+                console.log(
+                    `Dropping ${invalid.length} inline comment(s) outside the diff; folding into the review body.`
+                );
+                reviewCommentContent = {
+                    body: (reviewCommentContent.body ?? "") + renderCommentsAsBodySection(invalid, language),
+                    comments: valid,
+                };
+            }
+        }
+
+        // 8. GitHub にレビュー文を投稿。万一インライン投稿が拒否されても（フィルタ
+        // が取りこぼした端ケース等）、コメントを body に畳んで要約のみで再投稿し、
+        // 「レビューは走ったが投稿ゼロ」の無言失敗を避ける。
+        try {
+            await postReviewCommentFn({
+                octokit,
+                owner,
+                repo,
+                pullNumber,
+                reviewCommentContent,
+            });
+        } catch (postError) {
+            console.error(
+                "Inline review post failed; retrying as a body-only summary comment.",
+                postError
+            );
+            const foldedBody =
+                (reviewCommentContent.body ?? "") +
+                renderCommentsAsBodySection(reviewCommentContent.comments ?? [], language);
+            await postReviewCommentFn({
+                octokit,
+                owner,
+                repo,
+                pullNumber,
+                reviewCommentContent: { body: foldedBody, comments: [] },
+            });
+        }
 
     } catch (error) {
         console.error("Error in runReviewBotVercelAI:", error);

--- a/src/utils/runReviewBot.test.ts
+++ b/src/utils/runReviewBot.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the GitHub client so runReviewBotVercelAI runs without network. vi.mock is
+// hoisted, so the mock fns must come from vi.hoisted to exist when the factory runs.
+const { getMock, listFilesMock } = vi.hoisted(() => ({
+    getMock: vi.fn(),
+    listFilesMock: vi.fn(),
+}));
+
+vi.mock("@octokit/rest", () => ({
+    Octokit: class {
+        pulls = { get: getMock, listFiles: listFilesMock };
+    },
+}));
+
+import { runReviewBotVercelAI } from "./index";
+
+// Diff for a.ts → commentable new-file lines are {1,2,3,4} (added + context).
+const PATCH = [
+    "@@ -1,3 +1,4 @@",
+    " context1",
+    "-removed1",
+    "+added1",
+    "+added2",
+    " context2",
+].join("\n");
+
+const baseArgs = {
+    githubToken: "t",
+    owner: "o",
+    repo: "r",
+    pullNumber: 1,
+    excludePaths: [] as string[],
+    language: "Japanese",
+    modelCode: "claude-sonnet-4-6",
+};
+
+beforeEach(() => {
+    getMock.mockReset().mockResolvedValue({ data: { title: "T", body: "B" } });
+    listFilesMock
+        .mockReset()
+        .mockResolvedValue({ data: [{ filename: "a.ts", patch: PATCH }] });
+});
+
+describe("runReviewBotVercelAI inline hardening (#26)", () => {
+    it("drops out-of-diff comments and folds them into the body", async () => {
+        const post = vi.fn().mockResolvedValue(undefined);
+        const generate = vi.fn().mockResolvedValue({
+            body: "summary",
+            comments: [
+                { path: "a.ts", line: 2, body: "in-diff" },
+                { path: "a.ts", line: 999, body: "out-of-diff" },
+            ],
+        });
+
+        await runReviewBotVercelAI({
+            ...baseArgs,
+            generateReviewCommentFn: generate,
+            postReviewCommentFn: post,
+        });
+
+        expect(post).toHaveBeenCalledTimes(1);
+        const content = post.mock.calls[0][0].reviewCommentContent;
+        // only the in-diff comment is posted inline
+        expect(content.comments).toHaveLength(1);
+        expect(content.comments[0].line).toBe(2);
+        // the out-of-diff comment is preserved by folding it into the body,
+        // under the language-appropriate (Japanese) heading
+        expect(content.body).toContain("summary");
+        expect(content.body).toContain("out-of-diff");
+        expect(content.body).toContain("diff 範囲外");
+    });
+
+    it("posts normally when every comment is within the diff", async () => {
+        const post = vi.fn().mockResolvedValue(undefined);
+        const generate = vi.fn().mockResolvedValue({
+            body: "summary",
+            comments: [{ path: "a.ts", line: 3, body: "ok" }],
+        });
+
+        await runReviewBotVercelAI({
+            ...baseArgs,
+            generateReviewCommentFn: generate,
+            postReviewCommentFn: post,
+        });
+
+        expect(post).toHaveBeenCalledTimes(1);
+        const content = post.mock.calls[0][0].reviewCommentContent;
+        expect(content.comments).toHaveLength(1);
+        // nothing folded → no out-of-diff section
+        expect(content.body).not.toContain("diff 範囲外");
+    });
+
+    it("falls back to a body-only summary when the inline post fails", async () => {
+        const post = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("422 line could not be resolved"))
+            .mockResolvedValueOnce(undefined);
+        const generate = vi.fn().mockResolvedValue({
+            body: "summary",
+            comments: [{ path: "a.ts", line: 2, body: "in-diff" }],
+        });
+
+        await runReviewBotVercelAI({
+            ...baseArgs,
+            generateReviewCommentFn: generate,
+            postReviewCommentFn: post,
+        });
+
+        expect(post).toHaveBeenCalledTimes(2);
+        const retry = post.mock.calls[1][0].reviewCommentContent;
+        // retry carries no inline comments...
+        expect(retry.comments).toHaveLength(0);
+        // ...but folds the comment text into the body so nothing is silently lost
+        expect(retry.body).toContain("in-diff");
+    });
+});


### PR DESCRIPTION
resolve #26

## 概要

インライン投稿で、コメントが diff のハンク外の行を指すと `createReview` 全体が 422 で失敗し、**コメントが1件も付かない**問題を修正します。LLM はファイル全体を読んで行を選ぶため、変更のない行を指すことが普通に起き、無言の投稿ゼロが発生していました。

## 変更

- **`collectValidCommentLines`**: parsed diff から、各ファイルでコメント可能な new-file 行集合を構築（hunk 内の追加 `+`・コンテキスト ` ` 行。削除 `-` と `\ No newline` は除外）
- **`partitionCommentsByValidLines`**: コメントを diff 内 / diff 外に分割
- **`renderCommentsAsBodySection`**: diff 外コメントを review body に畳む。見出しは**レビュー言語に追従**（日本語 / 英語フォールバック）
- **`runReviewBotVercelAI`**:
  - 投稿前に diff 外コメントを除去し body に畳んで保全（破棄して無言で失うのを避ける）
  - 投稿を try/catch で包み、インライン投稿が失敗しても body のみで再投稿（「レビューは走ったが投稿ゼロ」を回避）
- 純粋関数に **vitest** を追加（13 tests green）、`dist/` 再ビルド

## 両モード対応

CODE / ACADEMIC とも、インライン（`single_comment=false`）は同じ `runReviewBotVercelAI` を通り、共通の `comments` 配列に対して処理するため**両モードで機能します**（学術コメントも `path`/`line` を持つ同形）。`single_comment=true` の経路は comments を持たないためフィルタは skip され、従来どおり body のみ投稿します。

## 設計メモ

- diff 外コメントは「破棄 or 最寄り行へスナップ」のうち、誤配置を避けるため**破棄＋body 畳み込み**を選択
- フォールバックはフィルタが取りこぼす稀な端ケースへの保険

## テスト

- `npm test`: 13 passed（新規 10 ＋ 既存 3）
- `npm run build` 済み、dist 反映済み

関連: #26, smkwlab/.github#46