### PR TITLE
fix: omit temperature for models that deprecated it (Opus 4.7+, Fable 5+)

### DIFF
--- a/dist/utils/generateAcademicReview.js
+++ b/dist/utils/generateAcademicReview.js
@@ -94,12 +94,9 @@ const generateAcademicReviewObject = (params) => __awaiter(void 0, void 0, void 
     const categoryMap = isJapanese ? categoryMapJa : categoryMapEn;
     try {
         const { object } = yield (0, index_1.withRetry)((...args_1) => __awaiter(void 0, [...args_1], void 0, function* (attempt = 1) {
-            return yield (0, ai_1.generateObject)({
-                schema: academicReviewSchema,
-                model: (0, provider_1.getModel)(modelCode),
-                prompt: userPrompt,
-                temperature: attempt === 1 ? 0 : 0.5
-            });
+            return yield (0, ai_1.generateObject)(Object.assign({ schema: academicReviewSchema, model: (0, provider_1.getModel)(modelCode), prompt: userPrompt }, ((0, provider_1.supportsTemperature)(modelCode)
+                ? { temperature: attempt === 1 ? 0 : 0.5 }
+                : {})));
         }), {
             maxAttempts: 3,
             initialDelayMs: 2000,

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -345,13 +345,9 @@ const generateReviewCommentObject = (params) => __awaiter(void 0, void 0, void 0
     try {
         // Use the retry mechanism for handling NoObjectGeneratedError
         const { object } = yield withRetry((...args_1) => __awaiter(void 0, [...args_1], void 0, function* (attempt = 1) {
-            return yield (0, ai_1.generateObject)({
-                schema: reviewSchema,
-                model: (0, provider_1.getModel)(modelCode),
-                prompt: userPrompt,
-                // Use temperature 0 for first attempt, 0.5 for retries
-                temperature: attempt === 1 ? 0 : 0.5
-            });
+            return yield (0, ai_1.generateObject)(Object.assign({ schema: reviewSchema, model: (0, provider_1.getModel)(modelCode), prompt: userPrompt }, ((0, provider_1.supportsTemperature)(modelCode)
+                ? { temperature: attempt === 1 ? 0 : 0.5 }
+                : {})));
         }), {
             maxAttempts: 3,
             initialDelayMs: 2000,

--- a/dist/utils/provider.js
+++ b/dist/utils/provider.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.resolveProvider = resolveProvider;
 exports.apiKeyEnvName = apiKeyEnvName;
 exports.getModel = getModel;
+exports.supportsTemperature = supportsTemperature;
 const google_1 = require("@ai-sdk/google");
 const anthropic_1 = require("@ai-sdk/anthropic");
 /**
@@ -31,4 +32,24 @@ function getModel(modelCode) {
     return resolveProvider(modelCode) === "anthropic"
         ? (0, anthropic_1.anthropic)(modelCode)
         : (0, google_1.google)(modelCode);
+}
+/**
+ * Whether a model accepts the `temperature` sampling parameter.
+ *
+ * Newer Anthropic models removed `temperature` (along with `top_p` / `top_k`):
+ * sending it returns a 400 ("`temperature` is deprecated for this model").
+ * Affected: Claude Opus 4.7+ and Claude Fable 5+. Opus 4.6 and earlier,
+ * Sonnet, Haiku, and all Google (Gemini) models still accept it.
+ *
+ * Ref: https://platform.claude.com/docs/en/about-claude/models/migration-guide
+ */
+function supportsTemperature(modelCode) {
+    // Fable 5 and later removed sampling parameters entirely.
+    if (/fable/i.test(modelCode))
+        return false;
+    // Claude Opus 4.7 / 4.8 (and later 4.x) removed them too; 4.6 still accepts.
+    const opus = modelCode.match(/opus-4-(\d+)/i);
+    if (opus && Number(opus[1]) >= 7)
+        return false;
+    return true;
 }

--- a/dist/utils/provider.js
+++ b/dist/utils/provider.js
@@ -45,11 +45,15 @@ function getModel(modelCode) {
  */
 function supportsTemperature(modelCode) {
     // Fable 5 and later removed sampling parameters entirely.
-    if (/fable/i.test(modelCode))
+    const fable = modelCode.match(/fable-(\d+)/i);
+    if (fable && Number(fable[1]) >= 5)
         return false;
-    // Claude Opus 4.7 / 4.8 (and later 4.x) removed them too; 4.6 still accepts.
-    const opus = modelCode.match(/opus-4-(\d+)/i);
-    if (opus && Number(opus[1]) >= 7)
-        return false;
+    // Opus 4.7+ and Opus 5+ removed them too; Opus 4.6 and earlier still accept.
+    const opus = modelCode.match(/opus-(\d+)-(\d+)/i);
+    if (opus) {
+        const [major, minor] = [Number(opus[1]), Number(opus[2])];
+        if (major > 4 || (major === 4 && minor >= 7))
+            return false;
+    }
     return true;
 }

--- a/src/utils/generateAcademicReview.ts
+++ b/src/utils/generateAcademicReview.ts
@@ -1,5 +1,5 @@
 import { generateText, generateObject, NoObjectGeneratedError } from "ai";
-import { getModel } from "./provider";
+import { getModel, supportsTemperature } from "./provider";
 import { z } from "zod";
 import { GenerateReviewCommentFn, GenerateReviewCommentFnParams, ReviewCommentContent, withRetry } from "./index";
 
@@ -110,7 +110,10 @@ export const generateAcademicReviewObject: GenerateReviewCommentFn = async (para
                     schema: academicReviewSchema,
                     model: getModel(modelCode),
                     prompt: userPrompt,
-                    temperature: attempt === 1 ? 0 : 0.5
+                    // Newer Anthropic models reject `temperature` (400); omit it there.
+                    ...(supportsTemperature(modelCode)
+                        ? { temperature: attempt === 1 ? 0 : 0.5 }
+                        : {})
                 });
             },
             {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { generateText, generateObject, NoObjectGeneratedError } from "ai";
-import { getModel } from "./provider";
+import { getModel, supportsTemperature } from "./provider";
 import { Octokit, RestEndpointMethodTypes } from "@octokit/rest";
 import { minimatch } from "minimatch";
 import { components } from "@octokit/openapi-types";
@@ -467,8 +467,11 @@ export const generateReviewCommentObject: GenerateReviewCommentFn = async (param
                     schema: reviewSchema,
                     model: getModel(modelCode),
                     prompt: userPrompt,
-                    // Use temperature 0 for first attempt, 0.5 for retries
-                    temperature: attempt === 1 ? 0 : 0.5
+                    // Use temperature 0 for first attempt, 0.5 for retries.
+                    // Newer Anthropic models reject `temperature` (400); omit it there.
+                    ...(supportsTemperature(modelCode)
+                        ? { temperature: attempt === 1 ? 0 : 0.5 }
+                        : {})
                 });
             },
             {

--- a/src/utils/provider.test.ts
+++ b/src/utils/provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveProvider, apiKeyEnvName } from "./provider";
+import { resolveProvider, apiKeyEnvName, supportsTemperature } from "./provider";
 
 describe("resolveProvider", () => {
     it("honours an explicit provider (case-insensitive), overriding the model code", () => {
@@ -26,5 +26,25 @@ describe("apiKeyEnvName", () => {
     it("maps each provider to its API key env var", () => {
         expect(apiKeyEnvName("anthropic")).toBe("ANTHROPIC_API_KEY");
         expect(apiKeyEnvName("google")).toBe("GEMINI_API_KEY");
+    });
+});
+
+describe("supportsTemperature", () => {
+    it("returns false for newer Anthropic models that removed sampling params", () => {
+        expect(supportsTemperature("claude-opus-4-7")).toBe(false);
+        expect(supportsTemperature("claude-opus-4-8")).toBe(false);
+        expect(supportsTemperature("CLAUDE-OPUS-4-8")).toBe(false);
+        expect(supportsTemperature("claude-fable-5")).toBe(false);
+    });
+
+    it("returns true for older Anthropic models that still accept temperature", () => {
+        expect(supportsTemperature("claude-opus-4-6")).toBe(true);
+        expect(supportsTemperature("claude-sonnet-4-6")).toBe(true);
+        expect(supportsTemperature("claude-haiku-4-5")).toBe(true);
+    });
+
+    it("returns true for Google (Gemini) models", () => {
+        expect(supportsTemperature("models/gemini-2.5-flash")).toBe(true);
+        expect(supportsTemperature("models/gemini-2.0-flash")).toBe(true);
     });
 });

--- a/src/utils/provider.test.ts
+++ b/src/utils/provider.test.ts
@@ -37,8 +37,15 @@ describe("supportsTemperature", () => {
         expect(supportsTemperature("claude-fable-5")).toBe(false);
     });
 
+    it("returns false for future Anthropic versions on the same trajectory", () => {
+        expect(supportsTemperature("claude-opus-4-9")).toBe(false); // future Opus 4.x
+        expect(supportsTemperature("claude-opus-5-0")).toBe(false); // future Opus 5+
+        expect(supportsTemperature("claude-fable-6")).toBe(false); // future Fable
+    });
+
     it("returns true for older Anthropic models that still accept temperature", () => {
         expect(supportsTemperature("claude-opus-4-6")).toBe(true);
+        expect(supportsTemperature("claude-opus-4-5")).toBe(true);
         expect(supportsTemperature("claude-sonnet-4-6")).toBe(true);
         expect(supportsTemperature("claude-haiku-4-5")).toBe(true);
     });

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -35,3 +35,22 @@ export function getModel(modelCode: string): LanguageModelV1 {
         ? anthropic(modelCode)
         : google(modelCode);
 }
+
+/**
+ * Whether a model accepts the `temperature` sampling parameter.
+ *
+ * Newer Anthropic models removed `temperature` (along with `top_p` / `top_k`):
+ * sending it returns a 400 ("`temperature` is deprecated for this model").
+ * Affected: Claude Opus 4.7+ and Claude Fable 5+. Opus 4.6 and earlier,
+ * Sonnet, Haiku, and all Google (Gemini) models still accept it.
+ *
+ * Ref: https://platform.claude.com/docs/en/about-claude/models/migration-guide
+ */
+export function supportsTemperature(modelCode: string): boolean {
+    // Fable 5 and later removed sampling parameters entirely.
+    if (/fable/i.test(modelCode)) return false;
+    // Claude Opus 4.7 / 4.8 (and later 4.x) removed them too; 4.6 still accepts.
+    const opus = modelCode.match(/opus-4-(\d+)/i);
+    if (opus && Number(opus[1]) >= 7) return false;
+    return true;
+}

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -48,9 +48,13 @@ export function getModel(modelCode: string): LanguageModelV1 {
  */
 export function supportsTemperature(modelCode: string): boolean {
     // Fable 5 and later removed sampling parameters entirely.
-    if (/fable/i.test(modelCode)) return false;
-    // Claude Opus 4.7 / 4.8 (and later 4.x) removed them too; 4.6 still accepts.
-    const opus = modelCode.match(/opus-4-(\d+)/i);
-    if (opus && Number(opus[1]) >= 7) return false;
+    const fable = modelCode.match(/fable-(\d+)/i);
+    if (fable && Number(fable[1]) >= 5) return false;
+    // Opus 4.7+ and Opus 5+ removed them too; Opus 4.6 and earlier still accept.
+    const opus = modelCode.match(/opus-(\d+)-(\d+)/i);
+    if (opus) {
+        const [major, minor] = [Number(opus[1]), Number(opus[2])];
+        if (major > 4 || (major === 4 && minor >= 7)) return false;
+    }
     return true;
 }


### PR DESCRIPTION
## 問題

新しい Anthropic モデル（Claude Opus 4.7 / 4.8、Fable 5）では \`temperature\`（および \`top_p\` / \`top_k\`）が削除されており、リクエストに含めると 400 エラーになる:

\`\`\`
`temperature` is deprecated for this model.
\`\`\`

このアクションは \`generateObject\` に \`temperature: attempt === 1 ? 0 : 0.5\` を常に渡していたため、これらのモデルを指定した caller（例: \`model_code: claude-opus-4-8\`）で AI レビューが失敗していた（smkwlab/tenbin_ex PR #197 で顕在化）。

## 修正

- \`provider.ts\` に \`supportsTemperature(modelCode)\` を追加
  - Fable 5+ / Opus 4.7+ → \`false\`（temperature を省略）
  - Opus 4.6 以前 / Sonnet / Haiku / Google(Gemini) → \`true\`（従来どおり送信）
- CODE レビュー（\`index.ts\`）と ACADEMIC レビュー（\`generateAcademicReview.ts\`）の \`generateObject\` 呼び出しで、サポートするモデルのときだけ \`temperature\` を spread して渡すよう変更
- \`provider.test.ts\` にテストを追加
- \`dist/\` を再ビルド（\`tsc\`）

## 動作確認

- \`npm test\` → 19 passed
- \`npm run build\` → 成功、dist 差分は意図した変更のみ

## 補足

temperature をサポートしないモデルでは、リトライ時の \`0.5\`（多様性付与）が効かなくなるが、リトライ自体（\`NoObjectGeneratedError\` に対する再試行）は従来どおり機能する。

参考: https://platform.claude.com/docs/en/about-claude/models/migration-guide