### PR TITLE
Fix diff line numbering on meta lines and align model defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ ai-academic-paper-reviewer/
 
 ### AI/ML Components
 - **Gemini AI**: Google's generative AI for review analysis
-- **Model**: gemini-2.0-flash (default)
+- **Model**: gemini-2.5-flash (default)
 - **Language Support**: Japanese/English review output
 
 ### Integration Features

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,7 +9,7 @@ const REPO = process.env.GITHUB_REPO;
 const EXCLUDE_PATHS = ((_a = process.env.EXCLUDE_PATHS) === null || _a === void 0 ? void 0 : _a.split(',').map(p => p.trim())) || [];
 const LANGUAGE = process.env.LANGUAGE || "English";
 const PR_NUMBER = Number(process.env.GITHUB_PR_NUMBER) || 1;
-const MODEL_CODE = process.env.MODEL_CODE || "models/gemini-2.0-flash";
+const MODEL_CODE = process.env.MODEL_CODE || "models/gemini-2.5-flash";
 const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW === 'true';
 const REVIEW_MODE = process.env.REVIEW_MODE || "CODE";
 // Check that the API key for the selected provider is configured (optional skip).

--- a/dist/utils/generateAcademicReview.js
+++ b/dist/utils/generateAcademicReview.js
@@ -26,6 +26,7 @@ const academicCommentSchema = zod_1.z.object({
         .describe("Specific and constructive feedback from an academic perspective. Include improvement suggestions from an educational viewpoint."),
     line: zod_1.z
         .number()
+        .int()
         .positive()
         .describe("The 1-based line number where the comment is placed. Corresponds to the new line number in the diff."),
     priority: zod_1.z

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -182,6 +182,7 @@ function formatHunkWithLineNumbers(hunk) {
                 // AI が誤って line 番号を取らないよう数字は出さず空白で埋める。
                 // collectValidCommentLines も同じ前提で new 側カウンタを
                 // 進めないため、両者の行番号観が一致する。
+                // 幅 9 はガター = old 4 桁 + 空白 1 + new 4 桁 に合わせる。
                 lineNumbers = "         ";
                 break;
         }

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -168,13 +168,21 @@ function formatHunkWithLineNumbers(hunk) {
                 lineNumbers = `     ${newLine.toString().padStart(4, " ")}`;
                 newLine++;
                 break;
-            default:
+            case " ":
                 // コンテキスト行の場合: oldLine/newLine 両方をインクリメント
                 lineNumbers = `${oldLine.toString().padStart(4, " ")} ${newLine
                     .toString()
                     .padStart(4, " ")}`;
                 oldLine++;
                 newLine++;
+                break;
+            default:
+                // メタ行 (e.g. "\ No newline at end of file")。
+                // 実在の行ではないのでカウンタは進めない。
+                // AI が誤って line 番号を取らないよう数字は出さず空白で埋める。
+                // collectValidCommentLines も同じ前提で new 側カウンタを
+                // 進めないため、両者の行番号観が一致する。
+                lineNumbers = "         ";
                 break;
         }
         return `${lineNumbers} | ${line}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const REPO = process.env.GITHUB_REPO
 const EXCLUDE_PATHS = process.env.EXCLUDE_PATHS?.split(',').map(p => p.trim()) || [];
 const LANGUAGE = process.env.LANGUAGE || "English"
 const PR_NUMBER = Number(process.env.GITHUB_PR_NUMBER) || 1;
-const MODEL_CODE = process.env.MODEL_CODE || "models/gemini-2.0-flash"
+const MODEL_CODE = process.env.MODEL_CODE || "models/gemini-2.5-flash"
 const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW === 'true'
 const REVIEW_MODE = process.env.REVIEW_MODE || "CODE"
 

--- a/src/local.ts
+++ b/src/local.ts
@@ -16,7 +16,7 @@ const REPO = process.env.GITHUB_REPO
 const EXCLUDE_PATHS = process.env.EXCLUDE_PATHS?.split(',').map(p => p.trim()) || [];
 const LANGUAGE = process.env.LANGUAGE || "English"
 const PR_NUMBER = Number(process.env.GITHUB_PR_NUMBER) || 1;
-const MODEL_CODE = process.env.MODEL_CODE || "models/gemini-2.0-flash"
+const MODEL_CODE = process.env.MODEL_CODE || "models/gemini-2.5-flash"
 const REVIEW_MODE = process.env.REVIEW_MODE || "CODE"
 
 if (!GITHUB_TOKEN) {

--- a/src/utils/generateAcademicReview.ts
+++ b/src/utils/generateAcademicReview.ts
@@ -19,6 +19,7 @@ const academicCommentSchema = z.object({
         ),
     line: z
         .number()
+        .int()
         .positive()
         .describe(
             "The 1-based line number where the comment is placed. Corresponds to the new line number in the diff."

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { parsePatch } from "diff";
 import {
     collectValidCommentLines,
+    createParsedDiffText,
     partitionCommentsByValidLines,
     renderCommentsAsBodySection,
 } from "./index";
@@ -46,6 +47,63 @@ describe("collectValidCommentLines", () => {
         const patch = ["@@ -1 +1 @@", "-old", "+new", "\\ No newline at end of file"].join("\n");
         const map = collectValidCommentLines([parsedFile("n.ts", patch)]);
         expect([...map.get("n.ts")!]).toEqual([1]); // only the added "new" line
+    });
+});
+
+// Extract the new-side (RIGHT) line numbers that the AI-facing diff text
+// presents as commentable: added (`+`) and context (` `) lines. The line-number
+// gutter rendered by createParsedDiffText is exactly 9 chars wide, followed by
+// " | " and the original diff line.
+function commentableLinesFromDiffText(text: string): number[] {
+    const nums: number[] = [];
+    for (const row of text.split("\n")) {
+        if (row.indexOf(" | ") !== 9) continue;
+        const gutter = row.slice(0, 9);
+        const marker = row.slice(12)[0];
+        if (marker === "+" || marker === " ") {
+            const right = gutter.slice(5).trim(); // new-side number
+            if (right) nums.push(Number(right));
+        }
+    }
+    return nums.sort((a, b) => a - b);
+}
+
+describe("createParsedDiffText line numbering", () => {
+    // A diff whose removed and added lines both lack a trailing newline, so the
+    // parsed hunk interleaves "\ No newline at end of file" meta lines. The meta
+    // lines must NOT advance the line counters, otherwise the numbers shown to
+    // the AI drift past what collectValidCommentLines considers valid.
+    const META_PATCH = [
+        "@@ -1,2 +1,2 @@",
+        " ctx",
+        "-old",
+        "\\ No newline at end of file",
+        "+new",
+        "\\ No newline at end of file",
+    ].join("\n");
+
+    it("does not let 'No newline' meta lines advance line numbers", () => {
+        const text = createParsedDiffText([parsedFile("n.ts", META_PATCH)]);
+        // ctx is new line 1, "new" is new line 2; meta lines carry no number.
+        expect(commentableLinesFromDiffText(text)).toEqual([1, 2]);
+    });
+
+    it("matches collectValidCommentLines for a diff with meta lines", () => {
+        const parsed = [parsedFile("n.ts", META_PATCH)];
+        const valid = [...collectValidCommentLines(parsed).get("n.ts")!].sort(
+            (a, b) => a - b
+        );
+        const shown = commentableLinesFromDiffText(createParsedDiffText(parsed));
+        expect(shown).toEqual(valid);
+    });
+
+    it("matches collectValidCommentLines for a multi-hunk diff", () => {
+        const parsed = [parsedFile("a.ts", PATCH)];
+        const valid = [...collectValidCommentLines(parsed).get("a.ts")!].sort(
+            (a, b) => a - b
+        );
+        const shown = commentableLinesFromDiffText(createParsedDiffText(parsed));
+        expect(shown).toEqual(valid);
     });
 });
 

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -50,18 +50,24 @@ describe("collectValidCommentLines", () => {
     });
 });
 
+// Layout of a rendered diff row produced by createParsedDiffText:
+// `<gutter><SEPARATOR><original diff line>`, where the gutter is a fixed-width
+// "<old> <new>" pair (each right-aligned to NUM_WIDTH) so its second half holds
+// the new-side number. These constants mirror that layout.
+const NUM_WIDTH = 4;
+const GUTTER_WIDTH = NUM_WIDTH + 1 + NUM_WIDTH; // "<old> <new>"
+const SEPARATOR = " | ";
+
 // Extract the new-side (RIGHT) line numbers that the AI-facing diff text
-// presents as commentable: added (`+`) and context (` `) lines. The line-number
-// gutter rendered by createParsedDiffText is exactly 9 chars wide, followed by
-// " | " and the original diff line.
+// presents as commentable: added (`+`) and context (` `) lines.
 function commentableLinesFromDiffText(text: string): number[] {
     const nums: number[] = [];
     for (const row of text.split("\n")) {
-        if (row.indexOf(" | ") !== 9) continue;
-        const gutter = row.slice(0, 9);
-        const marker = row.slice(12)[0];
+        if (row.indexOf(SEPARATOR) !== GUTTER_WIDTH) continue;
+        const gutter = row.slice(0, GUTTER_WIDTH);
+        const marker = row.slice(GUTTER_WIDTH + SEPARATOR.length)[0];
         if (marker === "+" || marker === " ") {
-            const right = gutter.slice(5).trim(); // new-side number
+            const right = gutter.slice(-NUM_WIDTH).trim(); // new-side number
             if (right) nums.push(Number(right));
         }
     }

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -66,6 +66,8 @@ function commentableLinesFromDiffText(text: string): number[] {
         if (row.indexOf(SEPARATOR) !== GUTTER_WIDTH) continue;
         const gutter = row.slice(0, GUTTER_WIDTH);
         const marker = row.slice(GUTTER_WIDTH + SEPARATOR.length)[0];
+        // Meta lines also reach here (their blank gutter is GUTTER_WIDTH wide),
+        // but their marker is "\\", so they fall through this +/context filter.
         if (marker === "+" || marker === " ") {
             const right = gutter.slice(-NUM_WIDTH).trim(); // new-side number
             if (right) nums.push(Number(right));

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -263,6 +263,7 @@ function formatHunkWithLineNumbers(hunk: Hunk): string {
                 // AI が誤って line 番号を取らないよう数字は出さず空白で埋める。
                 // collectValidCommentLines も同じ前提で new 側カウンタを
                 // 進めないため、両者の行番号観が一致する。
+                // 幅 9 はガター = old 4 桁 + 空白 1 + new 4 桁 に合わせる。
                 lineNumbers = "         ";
                 break;
         }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -249,13 +249,21 @@ function formatHunkWithLineNumbers(hunk: Hunk): string {
                 lineNumbers = `     ${newLine.toString().padStart(4, " ")}`;
                 newLine++;
                 break;
-            default:
+            case " ":
                 // コンテキスト行の場合: oldLine/newLine 両方をインクリメント
                 lineNumbers = `${oldLine.toString().padStart(4, " ")} ${newLine
                     .toString()
                     .padStart(4, " ")}`;
                 oldLine++;
                 newLine++;
+                break;
+            default:
+                // メタ行 (e.g. "\ No newline at end of file")。
+                // 実在の行ではないのでカウンタは進めない。
+                // AI が誤って line 番号を取らないよう数字は出さず空白で埋める。
+                // collectValidCommentLines も同じ前提で new 側カウンタを
+                // 進めないため、両者の行番号観が一致する。
+                lineNumbers = "         ";
                 break;
         }
 


### PR DESCRIPTION
resolve #32
resolve #33

ai-reviewer から派生したコードベースで本家に未追従だった整合性問題 2 件を修正します。

## #32: diff 行番号バグ（本番の誤動作）

`src/utils/index.ts` の `formatHunkWithLineNumbers()` が `\ No newline at end of file` メタ行をコンテキスト行として扱い、行カウンタを進めていた。一方で検証側 `collectValidCommentLines()` はメタ行をスキップするため、**AI に提示する行番号と投稿時に有効な行番号が 1 ずれ**、末尾改行のないファイルを含む diff でコメントの行ズレ・投稿失敗を引き起こしていた。

ai-reviewer の修正を移植:
- `case " ":`（コンテキスト行）を明示的に追加
- `default:` をメタ行専用にし、カウンタを進めず空白で埋める no-op に

### 回帰テスト
`createParsedDiffText` が AI に提示する右側（new 側）行番号が `collectValidCommentLines` の有効集合と一致する、という不変条件のテストを追加（メタ行を含む diff・複数 hunk の diff の両方）。修正前は `[1, 3]` を提示（メタ行で番号が drift）、修正後は `[1, 2]` で検証側と一致。

## #33: モデルデフォルト不一致 + スキーマの `.int()` 欠落

1. **デフォルトモデル**: `action.yml`/README は `models/gemini-2.5-flash` に更新済みだったが、`src/index.ts` / `src/local.ts` のフォールバックが `gemini-2.0-flash` のままで、環境変数未設定時に旧モデルへサイレントにフォールバックしていた。両ファイル（および CLAUDE.md の記述）を `2.5-flash` に統一。
2. **`.int()` 追加**: `generateAcademicReview.ts` の line スキーマが `z.number().positive()` のみで、structured output が小数の行番号を許し GitHub API 投稿時に失敗し得た。ai-reviewer と同じ `.int().positive()` に。

## テスト結果

- ✅ `npm run build`（tsc）: 型エラーなし、`dist/` 再生成済み
- ✅ `vitest run`: 全 19 テスト pass（うち新規 3 件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)