### PR TITLE
Use npm ci and pin setup-node in composite action (E-2)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,12 +44,14 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 22
 
     - name: Install dependencies
-      run: cd ${GITHUB_ACTION_PATH} && npm install --omit=dev
+      # npm ci gives a reproducible install from the committed package-lock.json
+      # (fails if lock and package.json drift), unlike npm install.
+      run: cd ${GITHUB_ACTION_PATH} && npm ci --omit=dev
       shell: bash
 
     - name: Run review bot


### PR DESCRIPTION
## Summary

Supply-chain hardening — **E-2** of the ecosystem security review (smkwlab/.github#69).

The composite action (`action.yml`) installed runtime deps with `npm install --omit=dev`, which resolves versions at runtime (non-reproducible), and used a mutable `actions/setup-node@v3` tag.

- **`npm install --omit=dev` → `npm ci --omit=dev`** — reproducible install straight from the committed `package-lock.json`; fails fast if the lock and `package.json` drift instead of silently pulling new versions on every action run.
- **Pin `actions/setup-node`** to a full commit SHA (`49933ea…`, bumped `v3` → `v4.4.0`; runs on the node20 runtime, `node-version: 22` unchanged).

## Verification

- `npm ci --omit=dev` succeeds against the current lockfile (38 packages, exit 0) → lock is in sync.
- `action.yml` YAML parses.

## Out of scope / follow-ups

- `npm audit` reports 3 advisories (1 low / 1 moderate / 1 high) in the dep tree — separate from this change; worth a follow-up bump PR.
- The repo's own `ci.yml` still uses mutable action tags — can be pinned in a follow-up (this PR keeps the blast radius to the action's runtime install).

Refs smkwlab/.github#69 (E-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)