### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Keep SHA-pinned third-party GitHub Actions up to date (Renovate here is
+  # mix-only, so it does not manage Actions). Reusable workflows stay on @v1.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary

Supply-chain hardening follow-up to smkwlab/.github#69 (items 2/3/5). Pins genuine third-party GitHub Actions in `.github/workflows/` to full commit SHAs (with a version comment), and adds Dependabot so the pins stay current.

## Changes

- `.github/workflows/ci.yml`
  - `actions/checkout@v4` -> `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - `actions/setup-node@v4` -> `@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
- `.github/dependabot.yml` (new) — weekly `github-actions` updates, grouped.

## Notes

- The reusable `smkwlab/.github/.github/workflows/ai-review.yml@v1` ref in `ai-code-review.yml` is **intentionally left on `@v1`** (the org's shared-CI channel).
- `action.yml`'s `setup-node` was already SHA-pinned in a prior merged PR — left unchanged.
- `dependabot.yml` is added because Renovate in this repo is mix-only and does not manage GitHub Actions.
- Validated with `actionlint`; YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
