### PR TITLE
Bump actions/setup-node to v6.4.0 (ci.yml + action.yml)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 22
 


### PR DESCRIPTION
Reviewed Renovate #40. setup-node v6 needs Runner v2.327.1+/Node 24, satisfied by GitHub-hosted `ubuntu-latest` (ci.yml + action.yml consumers). ci.yml is validated by this repo's PR CI. Consolidated to a fresh branch to clear the workflow-scope merge limitation. Supersedes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)