### PR TITLE
chore(renovate): exclude smkwlab/.github from pinDigests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>smkwlab/.github:latex#v1"],
-  "forkProcessing": "enabled"
+  "forkProcessing": "enabled",
+  "packageRules": [
+    {
+      "description": "Keep the smkwlab/.github reusable-workflow reference on the mutable @v1 channel: digest-pinning would freeze it and cut this repo off from centrally distributed updates",
+      "matchPackageNames": ["smkwlab/.github"],
+      "pinDigests": false
+    }
+  ]
 }


### PR DESCRIPTION
## 概要

Dependency Dashboard に `ci(deps): pin smkwlab/.github action to 3c24c80` が Awaiting Schedule で待機しており、生成されると `.github/workflows/ai-code-review.yml` の `ai-review.yml@v1` 参照が digest で凍結される。

- `@v1` は org の中央更新チャネル（v1 タグの force-move で全 consumer に配布）であり、digest pin すると本リポだけ配布から外れる
- pinDigest は default preset の auto-merge 対象のため、放置すると自動 merge される恐れがある
- 提案中の `3c24c80` は既に旧 v1（現 v1 = `2de593e` / v1.24.0）で、凍結された時点から stale

## 変更内容

`.github/renovate.json` に packageRule を追加し、`smkwlab/.github` を `pinDigests: false` に。バージョン更新（`vX.Y.Z` 参照の bump）は従来どおり Renovate が管理する。

Resolves #44

https://claude.ai/code/session_01A3UeXMSewEQ3dVRAKC95YR