### PR TITLE
chore(deps): upgrade the AI SDK to v7 and its providers to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.104",
-        "@ai-sdk/google": "^3.0.103",
+        "@ai-sdk/anthropic": "^4.0.27",
+        "@ai-sdk/google": "^4.0.31",
         "@octokit/rest": "^21.1.1",
-        "ai": "^6.0.240",
+        "ai": "^7.0.48",
         "diff": "^9.0.0",
         "dotenv": "^16.6.1",
         "minimatch": "^10.2.6",
@@ -26,79 +26,80 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.104",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.104.tgz",
-      "integrity": "sha512-D1d/whdUWF8KrXr9TzK6/S1wD9WmmxJ5DRWgGJX6Ip8iZW0up/yRtWuZwTkuX86bOPQTd2c370lIVteEBUGxPg==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-4.0.27.tgz",
+      "integrity": "sha512-ecrPWkYf+sHDLHErHAU/yjJfNevUzT0i6TuoQLb58oadnquSHcLQ5NMLLWjbr6d1rxYdzI7ftulIJ03VH9yM3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.41"
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.162",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.162.tgz",
-      "integrity": "sha512-Ful2sKX4/5iRIULrbKAN88VSduJKVxEIqub84uBT4SZkhYnu6pfWaFEzZOrjCwMf+ScWuxiFSAkZeXFphTji2w==",
+      "version": "4.0.37",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.37.tgz",
+      "integrity": "sha512-YBCTsSlX0ETVsjo0ihfBOeJ3p3y1wXKXDzF9Ygp9dscUY06dzOGmyWJSGsKg+khKVArzBWUW4UCSAKms20ZDmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.41",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "3.0.103",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.103.tgz",
-      "integrity": "sha512-i/I92bfAeRPBvAwrW052NmPTkc+ZgVYs3vZjGhHgReE04cV37xJtbhZgr6U3CZKDArIAN0NhL0GoLpZ7FYV+dA==",
+      "version": "4.0.31",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-4.0.31.tgz",
+      "integrity": "sha512-AFyO4MuHryrzr/ZEMHm/dEXwqABqoi4yIa9cfZxfI4VYM+dyPeZIXU4/qjvxiD6vzbitQhYf1jutQL/d71bymw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.41"
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
-      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.41",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.41.tgz",
-      "integrity": "sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==",
+      "version": "5.0.18",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.18.tgz",
+      "integrity": "sha512-UBNCrkxS5llgN2/RXLBRkjCFTIuL6YB1Goq5c+yRecnznhtX4XPjTwLHz2hrsTltTVZ0rqVegtnwFXdPBkjDHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider": "4.0.4",
         "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
         "eventsource-parser": "^3.0.8",
-        "undici": "^5.29.0"
+        "undici": "^7.28.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -580,15 +581,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -843,14 +835,6 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^24.2.0"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -1316,19 +1300,24 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ai": {
-      "version": "6.0.240",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.240.tgz",
-      "integrity": "sha512-nVytcmJmHAR+1UU3KlRQJ8Un8gePSAcbTfvShNGfbG9hYnQWKdyFRZWa4QBlKH5yiNLNqSS4Y9u0T0KcbY6FkA==",
+      "version": "7.0.48",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.48.tgz",
+      "integrity": "sha512-QmqshWFEDdkFFqSgdJ4cogaoDIYaedqbv73q/NXEYNkSIocJCzXnGFVyM9lrtAGTSBfm+5hq3/292ooXJ1jDSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.162",
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.41",
-        "@opentelemetry/api": "^1.9.0"
+        "@ai-sdk/gateway": "4.0.37",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -2103,15 +2092,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "vitest": "^4.1.10"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.104",
-    "@ai-sdk/google": "^3.0.103",
+    "@ai-sdk/anthropic": "^4.0.27",
+    "@ai-sdk/google": "^4.0.31",
     "@octokit/rest": "^21.1.1",
-    "ai": "^6.0.240",
+    "ai": "^7.0.48",
     "diff": "^9.0.0",
     "dotenv": "^16.6.1",
     "minimatch": "^10.2.6",


### PR DESCRIPTION
## 概要

AI SDK 一式の major 更新を 1 本にまとめる。Renovate が出している #59 / #55 / #56 を代替する。

| パッケージ | 変更前 | 変更後 | 対応する Renovate PR |
|---|---|---|---|
| `ai` | `^6.0.240` | `^7.0.48` | #59 |
| `@ai-sdk/anthropic` | `^3.0.104` | `^4.0.27` | #55 |
| `@ai-sdk/google` | `^3.0.103` | `^4.0.31` | #56 |

## なぜ 1 本にまとめるのか

3 つは互いに peer dependency を持たないため、**個別に merge できてしまうが、個別に merge すると壊れる**。

いずれも `@ai-sdk/provider-utils` を `4.0.41` → `5.0.18` へ引き上げる。1 つだけ上げると依存ツリーに 4.x と 5.x が同居し、プロバイダが返すモデルの型と `generateObject` が受け取る `LanguageModel` が無関係な型として扱われる。`src/utils/provider.ts` の `getModel()` が返す値を `src/utils/index.ts` と `src/utils/generateAcademicReview.ts` で使っているため、ここで型エラーになる。

Renovate はこの結合を検知できないので、人間が束ねる必要がある。

## 破壊的変更の影響

いずれもこのアクションには該当しない。

| パッケージ | Breaking change | 使用状況 |
|---|---|---|
| `ai` v7 | ストリーミングヘルパ（`toUIMessageStreamResponse` ほか）の非推奨化、`experimental_output` エイリアス削除 | **未使用**。`src/` にストリーミング関連の記述なし |
| `@ai-sdk/anthropic` v4 | `providerMetadata` から `cacheCreationInputTokens` を削除 | **未使用**。`providerMetadata` を読む箇所なし |
| `@ai-sdk/google` v4 | `GenerativeAI` 接辞の型・クラス名を変更 | **未使用**。`google` 関数のみ import |

`ai` から import しているのは `generateText` / `generateObject` / `NoObjectGeneratedError` と型 `LanguageModel` のみ。

## 検証

ローカルで 3 つを同時に適用して確認した。

```
provider-utils=5.0.18   （4.x との同居なし）

npm run build   → 成功
npm test        → Test Files 3 passed (3) / Tests 23 passed (23)
git diff -- dist → 差分なし（CI の dist 検証を通過）
```

`zod` は `^4.4.3`（#62 で更新済み）。`ai` v7 / プロバイダ v4 の peer requirement は `zod: "^3.25.76 || ^4.1.8"` で、現行構成を満たしている。

## 後始末

merge 後、#59 / #55 / #56 は Renovate が autoclose する見込み（更新が既に適用済みになるため）。残らない場合は手動で close する。
