### PR TITLE
ci: publish releases automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,14 @@
 #
 # This does NOT bring back the major-tag mover removed in #36. It only ever
 # creates a new tag; the frozen `v1` alias is never touched.
+#
+# Why not release-please or semantic-release: both decide whether to release
+# from the commit type, and this action is a thin wrapper whose substance is its
+# dependencies. Of the 22 commits behind the v1.10 release, nine were
+# `chore(deps)` and none were `feat` or `fix` — under either tool's defaults that
+# release, npm audit fix included, would never have been cut. Making them work
+# here means pushing Renovate to emit `fix(deps)` and still writing the dist/
+# check by hand, so the bespoke part moves rather than goes away.
 name: Release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+# Publishes a new immutable tag and release whenever something that consumers
+# actually run reaches main.
+#
+# Why this exists: consumers pin an exact tag (see the Release / Versioning
+# Policy in CLAUDE.md) and Renovate bumps that pin — but it can only bump to a
+# tag that exists. With releases cut by hand, main drifted for two months and
+# 22 commits, including an npm audit fix, never reached anyone (#65).
+#
+# This does NOT bring back the major-tag mover removed in #36. It only ever
+# creates a new tag; the frozen `v1` alias is never touched.
+name: Release
+
+on:
+  push:
+    branches: [main]
+    # Path-based, not commit-type-based. The action runs the committed dist/ at
+    # runtime, so a dependency bump IS a change to what consumers execute —
+    # treating `chore(deps)` as not worth releasing is what produced #65. What
+    # must not cut a release is a change consumers never see, and a `docs:`
+    # commit that happens to touch dist/ would slip past a type check.
+    paths:
+      - 'src/**'
+      - 'dist/**'
+      - 'action.yml'
+      - 'package.json'
+      - 'package-lock.json'
+  # Escape hatch: publish the current main on demand. Needed when a release has
+  # to go out for something the path filter deliberately ignores, and it is the
+  # only way to exercise this workflow without waiting for a source change.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Serialize so two merges landing together cannot compute the same next tag.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      # A re-run of this workflow would otherwise cut a second release for a
+      # commit that already has one.
+      - name: Skip if this commit is already released
+        id: guard
+        run: |
+          existing=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+$' | head -1)
+          if [ -n "$existing" ]; then
+            echo "::notice::${GITHUB_SHA} is already released as ${existing}"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        if: steps.guard.outputs.skip != 'true'
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.guard.outputs.skip != 'true'
+        run: npm ci
+
+      - name: Unit tests
+        if: steps.guard.outputs.skip != 'true'
+        run: npm test
+
+      - name: Build
+        if: steps.guard.outputs.skip != 'true'
+        run: npm run build
+
+      # Deliberately re-checked here rather than trusting the CI run on the same
+      # commit. Shipping a tag whose dist/ does not match src/ is worse than not
+      # shipping: the tag advances while the code consumers execute does not.
+      - name: Verify dist is up to date
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          if ! git diff --quiet -- dist; then
+            echo "::error::dist/ is out of date — run 'npm run build' and commit dist/."
+            git diff --stat -- dist
+            exit 1
+          fi
+
+      # Tags are vX.Y (CLAUDE.md). sort -V is what orders v1.9 before v1.10;
+      # the grep drops the frozen bare `v1` alias and the retired vX.Y.Z tags.
+      # A major bump stays a human act: tag v2.0 by hand and this picks up from
+      # there.
+      - name: Compute the next tag
+        id: next
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          latest=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          if [ -z "$latest" ]; then
+            echo "::error::no vX.Y tag found — refusing to guess a starting version"
+            exit 1
+          fi
+          major=${latest#v}; major=${major%%.*}
+          minor=${latest##*.}
+          next="v${major}.$((minor + 1))"
+          echo "::notice::${latest} -> ${next}"
+          echo "tag=${next}" >> "$GITHUB_OUTPUT"
+
+      - name: Tag and publish
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.next.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          gh release create "$TAG" --title "$TAG" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,15 +106,22 @@ jobs:
           next="v${major}.$((minor + 1))"
           echo "::notice::${latest} -> ${next}"
           echo "tag=${next}" >> "$GITHUB_OUTPUT"
+          echo "prev=${latest}" >> "$GITHUB_OUTPUT"
 
       - name: Tag and publish
         if: steps.guard.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.next.outputs.tag }}
+          PREV: ${{ steps.next.outputs.prev }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
-          gh release create "$TAG" --title "$TAG" --generate-notes
+          # --notes-start-tag is explicit because bare --generate-notes derives
+          # the range from the previous *release*, and several tags here
+          # (v1.3, v1.4, v1.8, v1.9) never got one. Anchoring to the previous
+          # vX.Y tag keeps the range right regardless of that history.
+          gh release create "$TAG" --title "$TAG" \
+            --generate-notes --notes-start-tag "$PREV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,12 +54,17 @@ jobs:
           fetch-depth: 0
 
       # A re-run of this workflow would otherwise cut a second release for a
-      # commit that already has one.
+      # commit that already has one. It guards against a repeat of an automatic
+      # run, so it does not apply to workflow_dispatch — there a human is asking
+      # for a release on purpose, and refusing would make the escape hatch
+      # useless exactly when the head commit is already tagged.
       - name: Skip if this commit is already released
         id: guard
+        env:
+          EVENT: ${{ github.event_name }}
         run: |
           existing=$(git tag --points-at HEAD | grep -E '^v[0-9]+\.[0-9]+$' | head -1)
-          if [ -n "$existing" ]; then
+          if [ -n "$existing" ] && [ "$EVENT" != workflow_dispatch ]; then
             echo "::notice::${GITHUB_SHA} is already released as ${existing}"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
@@ -123,13 +128,16 @@ jobs:
           TAG: ${{ steps.next.outputs.tag }}
           PREV: ${{ steps.next.outputs.prev }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
+          # gh creates the tag as part of creating the release, in one API call.
+          # Pushing the tag separately first would leave the tag behind if the
+          # release call then failed — and the guard above would read that tag on
+          # the next run and skip, so the release could never be made.
+          #
           # --notes-start-tag is explicit because bare --generate-notes derives
           # the range from the previous *release*, and several tags here
           # (v1.3, v1.4, v1.8, v1.9) never got one. Anchoring to the previous
           # vX.Y tag keeps the range right regardless of that history.
-          gh release create "$TAG" --title "$TAG" \
+          gh release create "$TAG" \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
             --generate-notes --notes-start-tag "$PREV"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,23 @@ jobs:
   Renovate bump it (GitHub Actions are managed org-wide by the shared Renovate
   preset; Dependabot is no longer used). Cut a **new** tag for each change —
   never re-push a published one.
+- Releases are cut by `.github/workflows/release.yml`, not by hand. Anything
+  reaching `main` that consumers actually run — `src/`, `dist/`, `action.yml`,
+  `package.json`, `package-lock.json` — publishes the next `vX.Y` tag and a
+  release. Documentation and workflow changes do not.
+  - This exists because releases used to depend on someone remembering. Renovate
+    can only bump a pin to a tag that exists, so when no tag was cut nothing
+    moved, and `main` drifted for two months and 22 commits — an npm audit fix
+    among them — before anyone noticed (#65). Nothing broke, which is why it
+    went unnoticed.
+  - Dependency-only changes release too. The action executes the committed
+    `dist/`, so a dependency bump *is* a change to what consumers run.
+  - The workflow re-runs the tests, the build and the `dist/` check itself
+    rather than trusting the CI run on the same commit. A tag whose `dist/`
+    does not match `src/` is worse than no tag: the version advances while the
+    executed code does not.
+  - A major bump stays a human act. Tag `v2.0` by hand and the workflow
+    continues from there.
 
 ## Security Considerations
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -33,7 +33,7 @@ jobs:
       - name: Academic Paper Review Bot
         # 不変のバージョンタグ（または commit SHA）に固定する。major タグ
         # `@v1` は force-move しないため依存しないこと。`v1.9` は例示なので、
-        # 最新タグは Releases ページで確認する（Dependabot で自動 bump 可）。
+        # 最新タグは Releases ページで確認する（Renovate で自動 bump 可）。
         uses: smkwlab/ai-academic-paper-reviewer@v1.9
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
 
 ## バージョニング
 
-各リリースは**新しい不変**タグ（現状は `vX.Y` 形式、例 `v1.9`）として公開され、公開済みタグは再プッシュしません。major タグ（`@v1`）は新リリースへ force-move しないため、利用者はこれが最新コードを暗黙的に追跡することに依存してはいけません。特定のバージョンタグ（現行タグは [Releases](../../releases) ページを参照、例 `@v1.9`）か full commit SHA に固定し、Dependabot で bump してください。これにより、共有タグを再プッシュした際に生じうる GitHub Actions の tarball キャッシュの陳腐化・不整合を回避できます。
+各リリースは**新しい不変**タグ（現状は `vX.Y` 形式、例 `v1.9`）として公開され、公開済みタグは再プッシュしません。major タグ（`@v1`）は新リリースへ force-move しないため、利用者はこれが最新コードを暗黙的に追跡することに依存してはいけません。特定のバージョンタグ（現行タグは [Releases](../../releases) ページを参照、例 `@v1.9`）か full commit SHA に固定し、Renovate で bump してください。これにより、共有タグを再プッシュした際に生じうる GitHub Actions の tarball キャッシュの陳腐化・不整合を回避できます。
 
 ## 機能
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
       - name: Academic Paper Review Bot
         # Pin to an immutable version tag (or a full commit SHA) — the major
         # tag `@v1` is not force-moved, so don't rely on it. `v1.9` is only an
-        # example; check the Releases page for the current tag (Dependabot can
+        # example; check the Releases page for the current tag (Renovate can
         # bump it for you).
         uses: smkwlab/ai-academic-paper-reviewer@v1.9
         with:
@@ -53,7 +53,7 @@ form, e.g. `v1.9`); published tags are never re-pushed. The major tag (`@v1`)
 is **not** force-moved to new releases, so consumers must not rely
 on it silently tracking the latest code. Pin to a specific version tag (see the
 [Releases](../../releases) page for the current one, e.g. `@v1.9`) or to a full
-commit SHA, and let Dependabot bump it. This avoids the stale/inconsistent
+commit SHA, and let Renovate bump it. This avoids the stale/inconsistent
 GitHub Actions tarball cache that can result when a shared tag is re-pushed.
 
 ## Features


### PR DESCRIPTION
Resolves #65

## 問題

消費者は固定タグを pin し、Renovate がそれを上げる方式になっている。しかし **Renovate は存在するタグにしか上げられない**。タグを切るのが人力なので、忘れると連鎖全体が止まる。しかも止まっても何も壊れないため検知されない。

実際 v1.9（2026-06-11）から 2 か月・22 commit が誰にも届いていなかった。その中には脆弱性修正が含まれる。

```
75d5330 Fix npm audit vulnerabilities (minimatch high + diff/brace-expansion/esbuild) (#42)
```

原因は #36 の副作用。削除した `release-updater.yml` は「配布」と「リリース発行」の 2 役を担っており、問題視されたのは前者（`git tag -fa v1 && push --force`）だったが、後者も一緒に消えた。

## 対応

`.github/workflows/release.yml` を追加し、消費者が実行するものが main に入ったら次の `vX.Y` タグと release を発行する。

### release-please を使わなかった理由

release-please は 3 セグメントの semver（`v1.11.0`）を前提とする。このリポジトリは `vX.Y` 形式で CLAUDE.md にもそう明記され、消費者は `@v1.10` を pin している。採番方式の変更は本件と無関係な破壊なので、既存形式を保つ小さな workflow にした。

### 発火条件はパス、commit の型ではない

```
src/** dist/** action.yml package.json package-lock.json → 発行する
README / CLAUDE.md / .github/**                          → 発行しない
```

依存更新のみでも発行する。この action は commit 済みの `dist/` を実行時に読むため、依存更新は消費者が実行するコードの変更そのものである。「依存だけだから配布しなくてよい」という判断が、まさに今回の事故の形をしている。

型で判定しなかったのは、`docs:` の commit に `dist/` の変更が紛れた場合に取りこぼすため。パスなら実体を見る。

### dist の検証を自前でやり直す

同じ commit に対する CI の結果を信用せず、workflow 内で `npm ci` → `npm test` → `npm run build` → `git diff --quiet -- dist` を通す。`dist/` が `src/` とずれたまま配布されると、**タグだけ進んで実行されるコードは古いまま**になる。これはタグを切らないより悪い。

### 再実行でタグが重複しない

HEAD に既に `vX.Y` タグが付いていれば skip する。これが無いと workflow の再実行が同じ commit に対して 2 本目の release を作る。

### force-move は復活させない

新しい不変タグを作るだけで、凍結された `@v1` には触れない。major 昇格は人の操作のまま（`v2.0` を手で切れば、以降はそこから続く）。

## 検証

採番と skip 判定を実タグに対して実行した。

```
$ git tag -l | grep -E '^v[0-9]+\.[0-9]+$' | sort -V | tail -1
v1.10                          → next=v1.11

$ printf 'v1.9\nv1.10\nv1.2\n' | sort -V
v1.2 v1.9 v1.10                ← v1.9 < v1.10 の順序が正しい

$ git tag -l | grep -E '^v[0-9]+\.[0-9]+$'
v1.3 … v1.10                   ← 3 セグメントの v1.0.x / v1.1.0 と裸の v1 は除外される

$ git tag --points-at v1.10 | grep -E '^v[0-9]+\.[0-9]+$'
v1.10                          → skip=true
```

`grep` が何も返さない場合にパイプ終端が `head`/`tail` なので、`set -e` 下でも落ちないことも確認済み。

`actionlint` は指摘なし。`npm test` は 23 件通過、`dist` は同期。

## 補足

この PR 自身は `.github/**` と docs しか触らないので、merge しても release は発行されない。`workflow_dispatch` を入れてあるので、動作を確認したい場合は手動実行で v1.11 を切れる（挙動の変わらない release になるが害はない）。次の実変更を待って確かめる形でもよい。

READMEs が「Dependabot で bump」と書いたままだったのも直した。Dependabot は #38 で Renovate に置き換え済み。
