### PR TITLE
chore(renovate): inherit the shared-workflow pin guard from the preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>smkwlab/.github:latex#v1"],
-  "forkProcessing": "enabled",
-  "packageRules": [
-    {
-      "description": "Keep the smkwlab/.github reusable-workflow reference on the mutable @v1 channel: digest-pinning would freeze it and cut this repo off from centrally distributed updates",
-      "matchPackageNames": ["smkwlab/.github"],
-      "pinDigests": false
-    }
-  ]
+  "forkProcessing": "enabled"
 }


### PR DESCRIPTION
## 背景

このリポジトリは `smkwlab/.github` への参照を digest 固定させないガードをローカルで持っていた。`:latex` preset が `pinDigests: true` を課しており、共有ワークフローの `@v1` 参照まで固定されてしまうためである。

同じ判断が共有 preset 側の既定になった（smkwlab/.github#136、v1.36.0 で配布済み）。**エコシステム全体で共有ワークフローは移動タグに揃える**方針で、ローカルガードは冗長になる。

同じ設定が 2 箇所にあると、片方だけ直したときに黙ってずれる。preset に一本化する。

## 変更内容

`.github/renovate.json` から `packageRules` を削除する。`forkProcessing` はこのリポジトリ固有の設定なので残す。

## 挙動が変わらないことの確認

削除後に preset から継承される値が、削除するローカル値と一致する。

```
$ gh api repos/smkwlab/.github/contents/latex.json?ref=v1 --jq .content | base64 -d \
    | jq '.packageRules[]|select(.matchPackageNames)|{matchPackageNames,pinDigests}'
{ "matchPackageNames": ["smkwlab/.github"], "pinDigests": false }
```

このリポジトリはこれまでもガードのおかげで `@v1` を保っていた唯一のリポジトリで、削除後も同じ状態が続く。ローカル定義に書いていた理由（digest 固定は中央配布から切り離す）は preset 側の `description` に、より詳しい形で移してある。

## 検証

マージ後、次回の Renovate 実行で参照が `@v1` のまま保たれることを確認する。

ref: smkwlab/latex-ecosystem#169
